### PR TITLE
Docker fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,19 @@
 .git
 docs/
 tests/
+src/
+finch.egg-info/
+
+# Any pywps generated log files
+**/*.log
+
+# Unit test / Coverage reports
+.cache
+.pytest_cache
+
+# PyCharm
+*.idea
+
+# Byte-compiled / optimized / DLL files
+**/__pycache__
+**/*.py[cod]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,27 +5,32 @@ LABEL Description="Finch WPS" Vendor="Birdhouse" Version="0.1.0"
 
 # Update Debian system
 RUN apt-get update && apt-get install -y \
- build-essential \
-&& rm -rf /var/lib/apt/lists/*
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
 
 # Update conda
 RUN conda update -n base conda
 
-# Copy WPS project
-COPY . /opt/wps
-
 WORKDIR /opt/wps
 
 # Create conda environment
-RUN conda env create -n wps -f environment.yml
+COPY environment.yml /opt/wps/environment.yml
+RUN conda env create -n wps -f environment.yml \
+    && rm -rf /opt/conda/pkgs/*
 
-# Install WPS
-RUN ["/bin/bash", "-c", "source activate wps && python setup.py develop"]
+# Copy WPS project
+COPY . /opt/wps
 
-# Start WPS service on port 5000 on 0.0.0.0
+# Add wps environent to the PATH. No need to activate the environment.
+ENV PATH /opt/conda/envs/wps/bin:$PATH
+
+RUN python setup.py install
+
+
 EXPOSE 5000
-ENTRYPOINT ["/bin/bash", "-c"]
-CMD ["source activate wps && exec emu start -b 0.0.0.0 -config /opt/wps/etc/demo.cfg"]
+
+ENTRYPOINT [ "/usr/bin/tini", "--"]
+CMD ["finch", "start", "-b", "0.0.0.0", "--config", "/opt/wps/etc/demo.cfg"]
 
 # docker build -t bird-house/finch .
 # docker run -p 5000:5000 bird-house/finch

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG pythonpath=/opt/python
 COPY environment.yml /opt/wps/environment.yml
 RUN conda env create -p ${pythonpath} -f environment.yml \
     # Install gunicorn to use as a production server
-    && conda install -p ${pythonpath} gunicorn \
+    && conda install -p ${pythonpath} gunicorn psycopg2 \
     && rm -rf /opt/conda/pkgs/*
 
 ## Add conda environent to the PATH. No need to activate the environment.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /code
 # Create conda environment
 COPY environment.yml environment.yml
 RUN conda env update -n base -f environment.yml \
-    && conda install gunicorn psycopg2 \
+    && conda install -c conda-forge gunicorn psycopg2 \
     && rm -rf /opt/conda/pkgs/*
 
 # Copy WPS project

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,26 +11,18 @@ RUN apt-get update && apt-get install -y \
 # Update conda
 RUN conda update -n base conda
 
-WORKDIR /opt/wps
-ARG pythonpath=/opt/python
+WORKDIR /code
 
 # Create conda environment
-COPY environment.yml /opt/wps/environment.yml
-RUN conda env create -p ${pythonpath} -f environment.yml \
-    # Install gunicorn to use as a production server
-    && conda install -p ${pythonpath} gunicorn psycopg2 \
+COPY environment.yml environment.yml
+RUN conda env update -n base -f environment.yml \
+    && conda install gunicorn psycopg2 \
     && rm -rf /opt/conda/pkgs/*
-
-## Add conda environent to the PATH. No need to activate the environment.
-ENV PATH ${pythonpath}/bin:$PATH
 
 # Copy WPS project
 COPY . .
 
-RUN python setup.py develop
-
-# Create a folder to save wps outputs. This can then be mounted as a volume on the host.
-RUN mkdir -p /data/wpsoutputs
+RUN python setup.py develop --no-deps
 
 EXPOSE 5000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ COPY . .
 
 RUN python setup.py develop
 
+# Create a folder to save wps outputs. This can then be mounted as a volume on the host.
 RUN mkdir -p /data/wpsoutputs
 
 EXPOSE 5000


### PR DESCRIPTION
## Overview

Changes:

- Don't copy the code before installing conda dependencies. This way the dependencies are cached by docker and subsequent builds are faster.
- Install gunicorn and psycopg2 to use in a production environment
- The default command starts gunicorn, but the development server can still be started by using: `docker run -p 5000:5000 finch finch [options] start`
