### PR TITLE
Added xclim processes to documentation (WIP)

### DIFF
--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -7,9 +7,95 @@ Processes
     :local:
     :depth: 1
 
-Say Hello
----------
+..
+   import finch
+   for p in finch.processes.processes:
+       c = p.__class__
+       doc = '.. autoprocess:: {}.{}\n'
+       print(doc.format(c.__module__, c.__name__))
 
-.. autoprocess:: finch.processes.wps_say_hello.SayHello
-   :docstring:
-   :skiplines: 1
+
+xclim Indicators
+----------------
+
+.. autoprocess:: finch.processes.xclim.cddProcess
+
+.. autoprocess:: finch.processes.xclim.cddcold_thresh_Process
+
+.. autoprocess:: finch.processes.xclim.consecutive_frost_daysProcess
+
+.. autoprocess:: finch.processes.xclim.csdi_window_Process
+
+.. autoprocess:: finch.processes.xclim.csi_thresh_Process
+
+.. autoprocess:: finch.processes.xclim.cwdProcess
+
+.. autoprocess:: finch.processes.xclim.dlyfrzthwProcess
+
+.. autoprocess:: finch.processes.xclim.dtrProcess
+
+.. autoprocess:: finch.processes.xclim.dtrvarProcess
+
+.. autoprocess:: finch.processes.xclim.etrProcess
+
+.. autoprocess:: finch.processes.xclim.frost_daysProcess
+
+.. autoprocess:: finch.processes.xclim.gddgrow_thresh_Process
+
+.. autoprocess:: finch.processes.xclim.gsl_thresh_Process
+
+.. autoprocess:: finch.processes.xclim.hddheat_thresh_Process
+
+.. autoprocess:: finch.processes.xclim.heat_wave_frequencyProcess
+
+.. autoprocess:: finch.processes.xclim.heat_wave_max_lengthProcess
+
+.. autoprocess:: finch.processes.xclim.hwi_thresh_Process
+
+.. autoprocess:: finch.processes.xclim.ice_daysProcess
+
+.. autoprocess:: finch.processes.xclim.prcptotProcess
+
+.. autoprocess:: finch.processes.xclim.r_thresh_mmProcess
+
+.. autoprocess:: finch.processes.xclim.rain_frzgrProcess
+
+.. autoprocess:: finch.processes.xclim.rx1dayProcess
+
+.. autoprocess:: finch.processes.xclim.rx_window_dayProcess
+
+.. autoprocess:: finch.processes.xclim.sdiiProcess
+
+.. autoprocess:: finch.processes.xclim.tg10pProcess
+
+.. autoprocess:: finch.processes.xclim.tg90pProcess
+
+.. autoprocess:: finch.processes.xclim.tg_meanProcess
+
+.. autoprocess:: finch.processes.xclim.tn10pProcess
+
+.. autoprocess:: finch.processes.xclim.tn90pProcess
+
+.. autoprocess:: finch.processes.xclim.tn_maxProcess
+
+.. autoprocess:: finch.processes.xclim.tn_meanProcess
+
+.. autoprocess:: finch.processes.xclim.tn_minProcess
+
+.. autoprocess:: finch.processes.xclim.tnlt_thresh_Process
+
+.. autoprocess:: finch.processes.xclim.tr_thresh_Process
+
+.. autoprocess:: finch.processes.xclim.tx10pProcess
+
+.. autoprocess:: finch.processes.xclim.tx90pProcess
+
+.. autoprocess:: finch.processes.xclim.tx_maxProcess
+
+.. autoprocess:: finch.processes.xclim.tx_meanProcess
+
+.. autoprocess:: finch.processes.xclim.tx_minProcess
+
+.. autoprocess:: finch.processes.xclim.txgt_thresh_Process
+
+.. autoprocess:: finch.processes.xclim.txgt_thresh_tasmax_tngt_thresh_tasmin_Process

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -8,8 +8,9 @@ Processes
     :depth: 1
 
 ..
-   import finch
-   for p in finch.processes.processes:
+   from finch.processes import processes
+   processes.sort()
+   for p in processes:
        c = p.__class__
        doc = '.. autoprocess:: {}.{}\n'
        print(doc.format(c.__module__, c.__name__))

--- a/finch/processes/__init__.py
+++ b/finch/processes/__init__.py
@@ -1,4 +1,4 @@
-from .wps_xclim_indices import XclimIndicatorProcess
+from .wps_xclim_indices import make_xclim_indicator_process
 from xclim import build_module
 import xclim.temperature
 import xclim.precip
@@ -22,10 +22,7 @@ def get_indicators(*args):
 indicators = get_indicators(xclim.temperature, xclim.precip)
 
 # Create PyWPS.Process subclasses
-classes = [XclimIndicatorProcess.make(ind) for ind in indicators]
-
-# Instantiate processes
-processes = [cls() for cls in classes]
+processes = [make_xclim_indicator_process(ind) for ind in indicators]
 
 
 # Create virtual module for indicators so Sphinx can find it.

--- a/finch/processes/__init__.py
+++ b/finch/processes/__init__.py
@@ -26,7 +26,6 @@ classes = [XclimIndicatorProcess.make(ind) for ind in indicators]
 
 # Instantiate processes
 processes = [cls() for cls in classes]
-processes.sort()
 
 # Create virtual module for indicators so Sphinx can find it.
 def _build_xclim():

--- a/finch/processes/__init__.py
+++ b/finch/processes/__init__.py
@@ -27,6 +27,7 @@ classes = [XclimIndicatorProcess.make(ind) for ind in indicators]
 # Instantiate processes
 processes = [cls() for cls in classes]
 
+
 # Create virtual module for indicators so Sphinx can find it.
 def _build_xclim():
     import sys
@@ -36,5 +37,6 @@ def _build_xclim():
     mod = build_module('finch.processes.xclim', objs, doc="""XCLIM Processes""")
     sys.modules['finch.processes.xclim'] = mod
     return mod
+
 
 xclim = _build_xclim()

--- a/finch/processes/__init__.py
+++ b/finch/processes/__init__.py
@@ -1,4 +1,5 @@
 from .wps_xclim_indices import XclimIndicatorProcess
+from xclim import build_module
 import xclim.temperature
 import xclim.precip
 
@@ -20,5 +21,21 @@ def get_indicators(*args):
 # List of Indicators that are exposed as WPS processes
 indicators = get_indicators(xclim.temperature, xclim.precip)
 
+# Create PyWPS.Process subclasses
+classes = [XclimIndicatorProcess.make(ind) for ind in indicators]
+
 # Instantiate processes
-processes = [XclimIndicatorProcess(i) for i in indicators]
+processes = [cls() for cls in classes]
+processes.sort()
+
+# Create virtual module for indicators so Sphinx can find it.
+def _build_xclim():
+    import sys
+
+    objs = {p.__class__.__name__: p.__class__ for p in processes}
+
+    mod = build_module('finch.processes.xclim', objs, doc="""XCLIM Processes""")
+    sys.modules['finch.processes.xclim'] = mod
+    return mod
+
+xclim = _build_xclim()

--- a/finch/processes/wps_xclim_indices.py
+++ b/finch/processes/wps_xclim_indices.py
@@ -17,7 +17,6 @@ import xarray as xr
 LOGGER = logging.getLogger("PYWPS")
 
 
-
 class XclimIndicatorProcess(Process):
 
     @classmethod
@@ -25,7 +24,7 @@ class XclimIndicatorProcess(Process):
         """Create a WPS Process subclass from an xclim Indicator class instance."""
         attrs = xci.json()
         name = attrs['identifier'].replace('{', '_').replace('}', '_').replace('__', '_')
-        return type(str(name)+'Process', (cls,), {'xci': xci, 'identifier': name})
+        return type(str(name) + 'Process', (cls,), {'xci': xci, 'identifier': name})
 
     def __init__(self):
         """Create a WPS process from an xclim indicator class instance."""

--- a/finch/processes/wps_xclim_indices.py
+++ b/finch/processes/wps_xclim_indices.py
@@ -17,19 +17,26 @@ import xarray as xr
 LOGGER = logging.getLogger("PYWPS")
 
 
+
 class XclimIndicatorProcess(Process):
 
-    def __init__(self, xci):
-        """Create a WPS process from an xclim indicator class instance."""
-        self.xci = xci
-
+    @classmethod
+    def make(cls, xci):
+        """Create a WPS Process subclass from an xclim Indicator class instance."""
         attrs = xci.json()
+        name = attrs['identifier'].replace('{', '_').replace('}', '_').replace('__', '_')
+        return type(str(name)+'Process', (cls,), {'xci': xci, 'identifier': name})
+
+    def __init__(self):
+        """Create a WPS process from an xclim indicator class instance."""
+
+        attrs = self.xci.json()
 
         outputs = [
             ComplexOutput('output_netcdf', 'Function output in netCDF',
                           abstract="The indicator values computed on the original input grid.",
                           as_reference=True,
-                          supported_formats=[FORMATS.NETCDF]
+                          supported_formats=[FORMATS.DODS, FORMATS.NETCDF]
                           ),
 
             ComplexOutput('output_log', 'Logging information',

--- a/finch/processes/wps_xclim_indices.py
+++ b/finch/processes/wps_xclim_indices.py
@@ -18,13 +18,20 @@ LOGGER = logging.getLogger("PYWPS")
 
 
 class XclimIndicatorProcess(Process):
+    """Dummy xclim indicator process class.
+
+    Set xci to the xclim indicator in order to have a working class"""
+    xci = None
 
     @classmethod
     def make(cls, xci):
-        """Create a WPS Process subclass from an xclim Indicator class instance."""
+        """Create a WPS Process subclass from an xclim `Indicator` class instance."""
         attrs = xci.json()
+
+        # Sanitize name
         name = attrs['identifier'].replace('{', '_').replace('}', '_').replace('__', '_')
-        return type(str(name) + 'Process', (cls,), {'xci': xci, 'identifier': name})
+
+        return type(str(name) + 'Process', (cls,), {'xci': xci, '__doc__': attrs['abstract']})
 
     def __init__(self):
         """Create a WPS process from an xclim indicator class instance."""
@@ -64,7 +71,7 @@ class XclimIndicatorProcess(Process):
         for name, attrs in params.items():
             if name in ['tas', 'tasmin', 'tasmax', 'pr', 'prsn']:
                 inputs.append(make_nc_input(name))
-            elif name in ['tn10', 'tn90']:
+            elif name in ['tn10', 'tn90', 't10', 't90']:
                 inputs.append(make_nc_input(name))
             elif name in ['thresh_tasmin', 'thresh_tasmax']:
                 inputs.append(make_thresh(name, attrs['default'], attrs['desc']))

--- a/tests/test_wps_xclim_indices.py
+++ b/tests/test_wps_xclim_indices.py
@@ -17,7 +17,7 @@ WPS, OWS = get_ElementMakerForVersion(VERSION)
 
 
 def test_wps_xclim_indices(tas_data_set):
-    client = client_for(Service(processes=[XclimIndicatorProcess(temperature.tg_mean)], cfgfiles=CFG_FILE))
+    client = client_for(Service(processes=[XclimIndicatorProcess.make(temperature.tg_mean)()], cfgfiles=CFG_FILE))
 
     datainputs = "tas=files@xlink:href=file://{fn};" \
                  "freq={freq}".format(fn=tas_data_set,
@@ -36,8 +36,8 @@ def test_wps_xclim_indices(tas_data_set):
 
 
 def test_wps_xclim_heat_wave_frequency(tasmin_data_set, tasmax_data_set):
-    process = XclimIndicatorProcess(temperature.heat_wave_frequency)
-    client = client_for(Service(processes=[process], cfgfiles=CFG_FILE))
+    process = XclimIndicatorProcess.make(temperature.heat_wave_frequency)
+    client = client_for(Service(processes=[process()], cfgfiles=CFG_FILE))
 
     request_doc = WPS.Execute(
         OWS.Identifier('heat_wave_frequency'),

--- a/tests/test_wps_xclim_indices.py
+++ b/tests/test_wps_xclim_indices.py
@@ -4,7 +4,7 @@ from pywps import Service
 from pywps.tests import client_for, assert_response_success
 
 from .common import get_output, CFG_FILE
-from finch.processes import XclimIndicatorProcess
+from finch.processes import make_xclim_indicator_process
 from xclim import temperature
 import xarray as xr
 from pathlib import Path
@@ -17,7 +17,7 @@ WPS, OWS = get_ElementMakerForVersion(VERSION)
 
 
 def test_wps_xclim_indices(tas_data_set):
-    client = client_for(Service(processes=[XclimIndicatorProcess.make(temperature.tg_mean)()], cfgfiles=CFG_FILE))
+    client = client_for(Service(processes=[make_xclim_indicator_process(temperature.tg_mean)], cfgfiles=CFG_FILE))
 
     datainputs = "tas=files@xlink:href=file://{fn};" \
                  "freq={freq}".format(fn=tas_data_set,
@@ -36,8 +36,8 @@ def test_wps_xclim_indices(tas_data_set):
 
 
 def test_wps_xclim_heat_wave_frequency(tasmin_data_set, tasmax_data_set):
-    process = XclimIndicatorProcess.make(temperature.heat_wave_frequency)
-    client = client_for(Service(processes=[process()], cfgfiles=CFG_FILE))
+    process = make_xclim_indicator_process(temperature.heat_wave_frequency)
+    client = client_for(Service(processes=[process], cfgfiles=CFG_FILE))
 
     request_doc = WPS.Execute(
         OWS.Identifier('heat_wave_frequency'),


### PR DESCRIPTION
## Overview

This PR fixes #11 

Changes:

* Added a class method to generate a Process subclass for each indicator. What this means is that processes are not created by doing `XclimIndicatorProcess.make(temperature.tg_mean)()` instead of `XclimIndicatorProcess(temperature.tg_mean)`
* Sanitized identifiers including thresholds, e.g. `{thresh}` -> `_thresh_`

This was done because the pywps autodoc extension expects a class, not an instance. Another option would be to modify the pywps extension to support both classes and instances. 

WIP do not merge. 