### PR TITLE
Identify opendap by header content description

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -67,7 +67,7 @@ def test_netcdf_to_csv_to_zip():
 
 
 def test_is_opendap_url():
-    # This test uses online requests, but the links shoudl be pretty stable.
+    # This test uses online requests, but the links should be pretty stable.
     # In case the link are no longer available, we should change the url.
     # This is better than skipping this test in CI.
 


### PR DESCRIPTION
## Overview

This PR fixes #23 
From the docstring of `is_opendap_url`:

>    The DAP Standard specifies that a specific tag must be included in the
    Content-Description header of every request. This tag is one of:
        "dods-dds" | "dods-das" | "dods-data" | "dods-error"
    So we can check if the header starts with `dods`.
    Even then, some OpenDAP servers seem to not include the specified header...
    So we need to let the netCDF4 library actually open the file.

## Additional Information

section 7.1.1 at: https://www.opendap.org/pdf/ESE-RFC-004v1.2.pdf

Also from the netcdf-java implementation: 

> Theres an ambiguity as to whether http://server/something is an OPeNDAP or an HTTP remote file using range requests. There will be more ambiguities in the future, as other HTTP based protocols are added. Currently we do a HEAD request on http://server/something.dds, and if it succeeds, and returns a header  Content-Description="dods-dds" or "dods_dds", then we open as OPeNDAP, and if it fails we try opening as an HTTP file. 

https://www.unidata.ucar.edu/software/netcdf-java/current/reference/DatasetUrls.html
