### PR TITLE
finch-usage.ipynb: ignore output in last print(log) to fix intermittent Jenkins failure

### DIFF
--- a/docs/source/notebooks/finch-usage.ipynb
+++ b/docs/source/notebooks/finch-usage.ipynb
@@ -238,6 +238,7 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "print(log)"
    ]
   }


### PR DESCRIPTION
On slow system, intermittently, we see this Jenkins error (note the "32%
Done" line added):

```
  _________ finch-master/docs/source/notebooks/finch-usage.ipynb::Cell 9 _________
  Notebook cell execution failed
  Cell 9: Cell outputs differ

  Input:
  print(log)

  Traceback:
   mismatch 'stdout'

   assert reference_output == test_output failed:

    'Processing s...cessfully\n\n' == 'Processing s...cessfully\n\n'
    Skipping 261 identical leading characters in diff, use -v to show
      1.0s
    + [####           ] | 32% Done |100% Done |  1.0s
      [###############] | 100% Done |  1.0s|100% Done |  1.0s
      Processing finished successfully
```

Is this `finch-usage.ipynb` the same as `finch.ipynb` in pavics-sdi (https://github.com/Ouranosinc/pavics-sdi/pull/148)?  We do test Finch notebooks in our Jenkins, so do we need the other notebooks in pavics-sdi?

## Overview

This PR fixes [issue id]

Changes:

* Added ...

## Related Issue / Discussion

## Additional Information

Links to other issues or sources.
