### PR TITLE
Refactor process composition

### DIFF
--- a/finch/processes/bccaqv2.py
+++ b/finch/processes/bccaqv2.py
@@ -1,0 +1,241 @@
+from copy import deepcopy
+from enum import Enum
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from pywps import ComplexInput, Process
+from pywps import configuration
+from pywps import ComplexInput, FORMATS
+from siphon.catalog import TDSCatalog
+import xarray as xr
+from xclim.checks import assert_daily
+
+from .utils import PywpsInput
+from .utils import single_input_or_none
+
+
+class ParsingMethod(Enum):
+    # parse the filename directly (faster and simpler, more likely to fail)
+    filename = 1
+    # parse each Data Attribute Structure (DAS) by appending .das to the url
+    # One request for each dataset, so lots of small requests to the Thredds server
+    opendap_das = 2
+    # open the dataset using xarray and look at the file attributes
+    # safer, but slower and lots of small requests are made to the Thredds server
+    xarray = 3
+
+
+def get_bccaqv2_local_files_datasets(
+    catalog_url, variable=None, rcp=None, method: ParsingMethod = ParsingMethod.filename
+) -> List[str]:
+    """Get a list of filenames corresponding to variable and rcp on a local filesystem."""
+    urls = []
+    for file in Path(catalog_url).glob("*.nc"):
+        if _bccaqv2_filter(method, file.stem, str(file), rcp, variable):
+            urls.append(str(file))
+    return urls
+
+
+def get_bccaqv2_opendap_datasets(
+    catalog_url, variable=None, rcp=None, method: ParsingMethod = ParsingMethod.filename
+) -> List[str]:
+    """Get a list of urls corresponding to variable and rcp on a Thredds server.
+
+    We assume that the files are named in a certain way on the Thredds server.
+
+    This is the case for boreas.ouranos.ca/thredds
+    For more general use cases, see the `xarray` and `requests` methods below."""
+
+    catalog = TDSCatalog(catalog_url)
+
+    urls = []
+    for dataset in catalog.datasets.values():
+        opendap_url = dataset.access_urls["OPENDAP"]
+        if _bccaqv2_filter(method, dataset.name, opendap_url, rcp, variable):
+            urls.append(opendap_url)
+    return urls
+
+
+def _bccaqv2_filter(method: ParsingMethod, filename, url, rcp, variable):
+    """Parse metadata and filter BCCAQV2 datasets"""
+
+    variable_ok = variable is None
+    rcp_ok = rcp is None
+
+    keep_models = [
+        m.lower()
+        for m in [
+            "BNU-ESM",
+            "CCSM4",
+            "CESM1-CAM5",
+            "CNRM-CM5",
+            "CSIRO-Mk3-6-0",
+            "CanESM2",
+            "FGOALS-g2",
+            "GFDL-CM3",
+            "GFDL-ESM2G",
+            "GFDL-ESM2M",
+            "HadGEM2-AO",
+            "HadGEM2-ES",
+            "IPSL-CM5A-LR",
+            "IPSL-CM5A-MR",
+            "MIROC-ESM-CHEM",
+            "MIROC-ESM",
+            "MIROC5",
+            "MPI-ESM-LR",
+            "MPI-ESM-MR",
+            "MRI-CGCM3",
+            "NorESM1-M",
+            "NorESM1-ME",
+            "bcc-csm1-1-m",
+            "bcc-csm1-1",
+        ]
+    ]
+
+    if method == ParsingMethod.filename:
+        variable_ok = variable_ok or filename.startswith(variable)
+        rcp_ok = rcp_ok or rcp in filename
+
+        filename_lower = filename.lower()
+        if not any(m in filename_lower for m in keep_models):
+            return False
+
+        if "r1i1p1" not in filename:
+            return False
+
+    elif method == ParsingMethod.opendap_das:
+
+        raise NotImplementedError("todo: filter models and runs")
+
+        # re_experiment = re.compile(r'String driving_experiment_id "(.+)"')
+        # lines = requests.get(url + ".das").content.decode().split("\n")
+        # variable_ok = variable_ok or any(
+        #     line.startswith(f"    {variable} {{") for line in lines
+        # )
+        # if not rcp_ok:
+        #     for line in lines:
+        #         match = re_experiment.search(line)
+        #         if match and rcp in match.group(1).split(","):
+        #             rcp_ok = True
+
+    elif method == ParsingMethod.xarray:
+
+        raise NotImplementedError("todo: filter models and runs")
+
+        # import xarray as xr
+
+        # ds = xr.open_dataset(url, decode_times=False)
+        # rcps = [
+        #     r
+        #     for r in ds.attrs.get("driving_experiment_id", "").split(",")
+        #     if "rcp" in r
+        # ]
+        # variable_ok = variable_ok or variable in ds.data_vars
+        # rcp_ok = rcp_ok or rcp in rcps
+
+    return rcp_ok and variable_ok
+
+
+def get_bccaqv2_inputs(wps_inputs, variable=None, rcp=None, catalog_url=None):
+    """Adds a 'resource' input list with bccaqv2 urls to WPS inputs."""
+    catalog_url = configuration.get_config_value("finch", "bccaqv2_url")
+    new_inputs = deepcopy(wps_inputs)
+    workdir = next(iter(wps_inputs.values()))[0].workdir
+
+    new_inputs["resource"] = []
+
+    def _make_bccaqv2_resource_input():
+        return ComplexInput(
+            "resource",
+            "NetCDF resource",
+            max_occurs=1000,
+            supported_formats=[FORMATS.NETCDF, FORMATS.DODS],
+        )
+
+    if catalog_url.startswith("http"):
+        for url in get_bccaqv2_opendap_datasets(catalog_url, variable, rcp):
+            resource = _make_bccaqv2_resource_input()
+            resource.url = url
+            resource.workdir = workdir
+            new_inputs["resource"].append(resource)
+    else:
+        for file in get_bccaqv2_local_files_datasets(catalog_url, variable, rcp):
+            resource = _make_bccaqv2_resource_input()
+            resource.file = file
+            resource.workdir = workdir
+            new_inputs["resource"].append(resource)
+
+    return new_inputs
+
+
+def _formatted_coordinate(value) -> Optional[str]:
+    """Returns the first value whether the input is a list of float or a 
+    single float"""
+    if not value:
+        return
+    try:
+        value = value.split(",")[0]
+    except (AttributeError):
+        pass
+    return f"{float(value):.3f}"
+
+
+def make_output_filename(process: Process, inputs: List[PywpsInput]):
+    """Returns a filename for the process's output, depending on its inputs"""
+
+    rcp = single_input_or_none(inputs, "rcp")
+    lat = _formatted_coordinate(single_input_or_none(inputs, "lat"))
+    lon = _formatted_coordinate(single_input_or_none(inputs, "lon"))
+    lat0 = _formatted_coordinate(single_input_or_none(inputs, "lat0"))
+    lon0 = _formatted_coordinate(single_input_or_none(inputs, "lon0"))
+    lat1 = _formatted_coordinate(single_input_or_none(inputs, "lat1"))
+    lon1 = _formatted_coordinate(single_input_or_none(inputs, "lon1"))
+
+    output_parts = [process.identifier]
+
+    if lat and lon:
+        output_parts.append(f"{float(lat):.3f}")
+        output_parts.append(f"{float(lon):.3f}")
+    elif lat0 and lon0:
+        output_parts.append(f"{float(lat0):.3f}")
+        output_parts.append(f"{float(lon0):.3f}")
+
+    if lat1 and lon1:
+        output_parts.append(f"{float(lat1):.3f}")
+        output_parts.append(f"{float(lon1):.3f}")
+
+    if rcp:
+        output_parts.append(rcp)
+
+    return "_".join(output_parts)
+
+
+def fix_broken_time_indices(tasmin: Path, tasmax: Path) -> Tuple[Path, Path]:
+    """In a single bccaqv2 dataset, there is an error in the timestamp data.
+
+    2036-10-28 time step coded as 1850-01-01
+    tasmax_day_BCCAQv2+ANUSPLIN300_CESM1-CAM5_historical+rcp85_r1i1p1_19500101-21001231_sub.nc
+    """
+    tasmin_ds = xr.open_dataset(tasmin)
+    tasmax_ds = xr.open_dataset(tasmax)
+
+    def fix(correct_ds, wrong_ds, original_filename):
+        wrong_ds["time"] = correct_ds.time
+        temp_name = original_filename.with_name(original_filename.stem + "_temp")
+        wrong_ds.to_netcdf(temp_name)
+        original_filename.unlink()
+        temp_name.rename(original_filename)
+
+    try:
+        assert_daily(tasmin_ds)
+    except ValueError:
+        fix(tasmax_ds, tasmin_ds, tasmin)
+        return tasmin, tasmax
+
+    try:
+        assert_daily(tasmax_ds)
+    except ValueError:
+        fix(tasmin_ds, tasmax_ds, tasmax)
+        return tasmin, tasmax
+
+    return tasmin, tasmax

--- a/finch/processes/bccaqv2.py
+++ b/finch/processes/bccaqv2.py
@@ -1,11 +1,10 @@
 from copy import deepcopy
 from enum import Enum
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
-from pywps import ComplexInput, Process
+from pywps import ComplexInput, FORMATS, Process
 from pywps import configuration
-from pywps import ComplexInput, FORMATS
 from siphon.catalog import TDSCatalog
 import xarray as xr
 from xclim.checks import assert_daily
@@ -169,13 +168,15 @@ def get_bccaqv2_inputs(wps_inputs, variable=None, rcp=None, catalog_url=None):
 
 
 def _formatted_coordinate(value) -> Optional[str]:
-    """Returns the first value whether the input is a list of float or a 
-    single float"""
+    """Returns the first float value.
+
+    The value can be a comma separated list of floats or a single float
+    """
     if not value:
         return
     try:
         value = value.split(",")[0]
-    except (AttributeError):
+    except AttributeError:
         pass
     return f"{float(value):.3f}"
 

--- a/finch/processes/subset.py
+++ b/finch/processes/subset.py
@@ -21,7 +21,7 @@ LOGGER = logging.getLogger("PYWPS")
 
 def finch_subset_gridpoint(process: Process, inputs: RequestInputs) -> List[Path]:
     """Parse wps inputs based on their name and execute the correct subset function.
-    
+
     The expected names of the inputs are as followed (taken from `wpsio.py`):
      - resource: ComplexInput files to subset.
      - lat: Latitude coordinate, can be a comma separated list of floats
@@ -101,7 +101,7 @@ def finch_subset_gridpoint(process: Process, inputs: RequestInputs) -> List[Path
 
 def finch_subset_bbox(process: Process, inputs: RequestInputs) -> List[Path]:
     """Parse wps inputs based on their name and execute the correct subset function.
-    
+
     The expected names of the inputs are as followed (taken from `wpsio.py`):
      - resource: ComplexInput files to subset.
      - lat0: Latitude coordinate

--- a/finch/processes/subset.py
+++ b/finch/processes/subset.py
@@ -1,53 +1,157 @@
 import logging
-from multiprocessing.pool import ThreadPool
 from pathlib import Path
+from typing import List
 
-from pywps import FORMATS
-from pywps.inout.outputs import MetaLink4, MetaFile
+from pywps import Process, ComplexInput
+from pywps.app.exceptions import ProcessError
+from xclim.subset import subset_gridpoint, subset_bbox
+import xarray as xr
 
-from finch.processes.base import FinchProcess
+from finch.processes.utils import (
+    RequestInputs,
+    single_input_or_none,
+    try_opendap,
+    process_threaded,
+)
 
 LOGGER = logging.getLogger("PYWPS")
 
 
-class SubsetProcess(FinchProcess):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+def finch_subset_gridpoint(process: Process, inputs: RequestInputs) -> List[Path]:
+    """Parse wps inputs based on their name and execute the correct subset function.
+    
+    The expected names of the inputs are as followed (taken from `wpsio.py`):
+     - resource: ComplexInput files to subset.
+     - lat: Latitude coordinate, can be a comma separated list of floats
+     - lon: Longitude coordinate, can be a comma separated list of floats
+     - start_date: Initial date for temporal subsetting.
+     - end_date: Final date for temporal subsetting.
+    """
 
-    def subset_resources(self, resources, subset_function, threads=1) -> MetaLink4:
-        metalink = MetaLink4(
-            identity="subset_bbox",
-            description="Subsetted netCDF files",
-            publisher="Finch",
-            workdir=self.workdir,
+    lon_value = inputs["lon"][0].data
+    try:
+        longitudes = [float(l) for l in lon_value.split(",")]
+    except AttributeError:
+        longitudes = [float(lon_value)]
+
+    lat_value = inputs["lat"][0].data
+    try:
+        latitudes = [float(l) for l in lat_value.split(",")]
+    except AttributeError:
+        latitudes = [float(lat_value)]
+
+    start_date = single_input_or_none(inputs, "start_date")
+    end_date = single_input_or_none(inputs, "end_date")
+    variables = [r.data for r in inputs.get("variable", [])]
+
+    n_files = len(inputs["resource"])
+    count = 0
+
+    output_files = []
+
+    def _subset(resource: ComplexInput):
+        nonlocal count
+
+        # if not subsetting by time, it's not necessary to decode times
+        time_subset = start_date is not None or end_date is not None
+        dataset = try_opendap(resource, decode_times=time_subset)
+
+        count += 1
+
+        percentage = int((count - 1) / n_files)
+
+        dataset = dataset[variables] if variables else dataset
+
+        subsets = []
+        for longitude, latitude in zip(longitudes, latitudes):
+            subset = subset_gridpoint(
+                dataset,
+                lon=longitude,
+                lat=latitude,
+                start_date=start_date,
+                end_date=end_date,
+            )
+            subsets.append(subset)
+
+        subsetted = xr.concat(subsets, dim="region")
+
+        if not all(subsetted.dims.values()):
+            LOGGER.warning(f"Subset is empty for dataset: {resource.url}")
+            return
+
+        p = Path(resource._file or resource._build_file_name(resource.url))
+        output_filename = Path(process.workdir) / (p.stem + "_sub" + p.suffix)
+
+        subsetted.to_netcdf(output_filename)
+
+        output_files.append(output_filename)
+
+    process_threaded(_subset, inputs["resource"])
+
+    return output_files
+
+
+def finch_subset_bbox(process: Process, inputs: RequestInputs) -> List[Path]:
+    """Parse wps inputs based on their name and execute the correct subset function.
+    
+    The expected names of the inputs are as followed (taken from `wpsio.py`):
+     - resource: ComplexInput files to subset.
+     - lat0: Latitude coordinate
+     - lon0: Longitude coordinate
+     - lat1: Latitude coordinate
+     - lon1: Longitude coordinate
+     - start_date: Initial date for temporal subsetting.
+     - end_date: Final date for temporal subsetting.
+    """
+    lon0 = single_input_or_none(inputs, "lon0")
+    lat0 = single_input_or_none(inputs, "lat0")
+    lon1 = single_input_or_none(inputs, "lon1")
+    lat1 = single_input_or_none(inputs, "lat1")
+    start_date = single_input_or_none(inputs, "start_date")
+    end_date = single_input_or_none(inputs, "end_date")
+    variables = [r.data for r in inputs.get("variable", [])]
+
+    nones = [lat1 is None, lon1 is None]
+    if any(nones) and not all(nones):
+        raise ProcessError("lat1 and lon1 must be both omitted or provided")
+
+    n_files = len(inputs["resource"])
+    count = 0
+
+    output_files = []
+
+    def _subset(resource):
+        nonlocal count
+
+        # if not subsetting by time, it's not necessary to decode times
+        time_subset = start_date is not None or end_date is not None
+        dataset = try_opendap(resource, decode_times=time_subset)
+
+        count += 1
+
+        percentage = int((count - 1) / n_files)
+
+        dataset = dataset[variables] if variables else dataset
+
+        subsetted = subset_bbox(
+            dataset,
+            lon_bnds=[lon0, lon1],
+            lat_bnds=[lat0, lat1],
+            start_date=start_date,
+            end_date=end_date,
         )
 
-        def process_resource(resource):
-            out = subset_function(resource)
+        if not all(subsetted.dims.values()):
+            LOGGER.warning(f"Subset is empty for dataset: {resource.url}")
+            return
 
-            if not all(out.dims.values()):
-                LOGGER.warning(f"Subset is empty for dataset: {resource.url}")
-                return
+        p = Path(resource._file or resource._build_file_name(resource.url))
+        output_filename = Path(process.workdir) / (p.stem + "_sub" + p.suffix)
 
-            p = Path(resource._file or resource._build_file_name(resource.url))
-            out_fn = Path(self.workdir) / (p.stem + "_sub" + p.suffix)
+        subsetted.to_netcdf(output_filename)
 
-            out.to_netcdf(out_fn)
+        output_files.append(output_filename)
 
-            mf = MetaFile(
-                identity=p.stem,
-                fmt=FORMATS.NETCDF,
-            )
-            mf.file = str(out_fn)
-            metalink.append(mf)
+    process_threaded(_subset, inputs["resource"])
 
-        if threads > 1:
-            pool = ThreadPool(processes=threads)
-            list(pool.imap_unordered(process_resource, resources))
-            pool.close()
-            pool.join()
-        else:
-            for r in resources:
-                process_resource(r)
-
-        return metalink
+    return output_files

--- a/finch/processes/utils.py
+++ b/finch/processes/utils.py
@@ -1,8 +1,7 @@
 import logging
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
-from pathlib import Path
-from typing import Callable, Dict, Generator, Iterable, List, Tuple, Union, Deque
+from typing import Callable, Deque, Dict, Generator, Iterable, List, Tuple, Union
 import zipfile
 
 import netCDF4
@@ -41,7 +40,7 @@ def write_log(
      - To a log file stored in the process working directory
      - Update the response document with the message and the status percentage
 
-    subtask_percentage: not the percentage of the whole process, but the percent done 
+    subtask_percentage: not the percentage of the whole process, but the percent done
     in the current processing step. (see `process.status_percentage_steps`)
     """
     LOGGER.log(level, message)
@@ -107,8 +106,8 @@ def try_opendap(
     decode_times=True,
     logging_function=lambda message: None,
 ) -> xr.Dataset:
-    """Try to open the file as an OPeNDAP url and chunk it. 
-    
+    """Try to open the file as an OPeNDAP url and chunk it.
+
     If OPeNDAP fails, access the file directly.
     """
     url = input.url

--- a/finch/processes/wps_bccaqv2_heatwave.py
+++ b/finch/processes/wps_bccaqv2_heatwave.py
@@ -1,29 +1,34 @@
-import logging
-import warnings
 from collections import deque
-from typing import List, Tuple
-
-import numpy as np
-import xarray as xr
-from xclim.checks import assert_daily
-from xclim.atmos import heat_wave_frequency
+import logging
 from pathlib import Path
-from pywps.response.execute import ExecuteResponse
-from pywps.app.exceptions import ProcessError
-from pywps.app import WPSRequest
-from .wpsio import lat, lon
-from pywps import LiteralInput, ComplexOutput, FORMATS, configuration
-import sentry_sdk
+import warnings
 
-from finch.processes import make_xclim_indicator_process, SubsetGridPointProcess
-from finch.processes.subset import SubsetProcess
-from finch.processes.utils import get_bccaqv2_inputs, netcdf_to_csv, zip_files
-from finch.processes.wps_xclim_indices import make_nc_input
+from pywps import ComplexOutput, FORMATS, LiteralInput
+from pywps.app import WPSRequest
+from pywps.app.exceptions import ProcessError
+from pywps.response.execute import ExecuteResponse
+from xclim.atmos import heat_wave_frequency
+
+from finch.processes import make_xclim_indicator_process
+
+from .base import FinchProcess
+from .bccaqv2 import get_bccaqv2_inputs, make_output_filename, fix_broken_time_indices
+from .subset import finch_subset_gridpoint
+from .utils import (
+    compute_indices,
+    make_tasmin_tasmax_pairs,
+    netcdf_to_csv,
+    single_input_or_none,
+    write_log,
+    zip_files,
+)
+from .wps_xclim_indices import make_nc_input
+from .wpsio import lat, lon
 
 LOGGER = logging.getLogger("PYWPS")
 
 
-class BCCAQV2HeatWave(SubsetGridPointProcess):
+class BCCAQV2HeatWave(FinchProcess):
     """Subset a NetCDF file using a gridpoint, and then compute the 'heat wave' index."""
 
     def __init__(self):
@@ -71,8 +76,7 @@ class BCCAQV2HeatWave(SubsetGridPointProcess):
             )
         ]
 
-        SubsetProcess.__init__(
-            self,
+        super().__init__(
             self._handler,
             identifier="BCCAQv2_heat_wave_frequency_gridpoint",
             title="BCCAQv2 grid cell heat wave frequency computation",
@@ -87,75 +91,40 @@ class BCCAQV2HeatWave(SubsetGridPointProcess):
             store_supported=True,
         )
 
-    def _make_tasmin_tasmax_pairs(self, filenames: List[Path]):
-        tasmin_files = [f for f in filenames if "tasmin" in f.name.lower()]
-        tasmax_files = [f for f in filenames if "tasmax" in f.name.lower()]
-        for tasmin in tasmin_files[:]:
-            for tasmax in tasmax_files[:]:
-                if tasmin.name.lower() == tasmax.name.lower().replace(
-                    "tasmax", "tasmin"
-                ):
-                    yield tasmin, tasmax
-                    tasmax_files.remove(tasmax)
-                    tasmin_files.remove(tasmin)
-                    break
-        for f in tasmax_files + tasmax_files:
-            sentry_sdk.capture_message(
-                f"Couldn't find matching tasmin or tasmax for: {f}", level="error"
-            )
-
     def _handler(self, request: WPSRequest, response: ExecuteResponse):
-        self.write_log("Processing started", response, 5)
+        self.percentage = 5
+        write_log(self, "Processing started")
 
-        lat = request.inputs["lat"][0].data
-        lon = request.inputs["lon"][0].data
-        output_format = request.inputs["output_format"][0].data
-        output_filename = f"BCCAQv2_subset_heat_wave_frequency_{lat}_{lon}"
+        output_filename = make_output_filename(self, request.inputs)
 
-        self.write_log("Fetching BCCAQv2 datasets", response, 6)
-        tasmin_inputs = get_bccaqv2_inputs(request.inputs, "tasmin")["resource"]
-        tasmax_inputs = get_bccaqv2_inputs(request.inputs, "tasmax")["resource"]
+        write_log(self, "Fetching BCCAQv2 datasets")
 
-        request.inputs["resource"] = tasmin_inputs + tasmax_inputs
+        variable = single_input_or_none(request.inputs, "variable")
+        rcp = single_input_or_none(request.inputs, "rcp")
+        request.inputs = get_bccaqv2_inputs(request.inputs, variable=variable, rcp=rcp)
 
-        self.write_log("Running subset", response, 7)
+        self.percentage = 7
+        write_log(self, "Running subset")
 
-        threads = int(configuration.get_config_value("finch", "subset_threads"))
+        output_files = finch_subset_gridpoint(self, request.inputs)
 
-        metalink = self.subset(
-            request.inputs,
-            response,
-            start_percentage=7,
-            end_percentage=70,
-            threads=threads,
-        )
-
-        if not metalink.files:
+        if not output_files:
             message = "No data was produced when subsetting using the provided bounds."
             raise ProcessError(message)
 
-        self.write_log("Subset done, calculating indices", response)
+        write_log(self, "Subset done, calculating indices")
 
-        all_files = [Path(f.file) for f in metalink.files]
-
-        pairs = list(self._make_tasmin_tasmax_pairs(all_files))
+        pairs = list(make_tasmin_tasmax_pairs(output_files))
         n_pairs = len(pairs)
 
-        start_percentage, end_percentage = 70, 95
         output_files = []
 
         warnings.filterwarnings("ignore", category=FutureWarning)
         warnings.filterwarnings("ignore", category=UserWarning)
 
         for n, (tasmin, tasmax) in enumerate(pairs):
-            percentage = start_percentage + int(
-                n / n_pairs * (end_percentage - start_percentage)
-            )
-            self.write_log(
-                f"Computing indices for file {n + 1} of {n_pairs}",
-                response,
-                percentage,
-            )
+            percentage = int(n / n_pairs * 100)
+            write_log(self, f"Computing indices for file {n + 1} of {n_pairs}")
 
             tasmin, tasmax = fix_broken_time_indices(tasmin, tasmax)
 
@@ -167,7 +136,7 @@ class BCCAQV2HeatWave(SubsetGridPointProcess):
             inputs["tasmax"] = deque([make_nc_input("tasmax")], maxlen=1)
             inputs["tasmax"][0].file = str(tasmax)
 
-            out = self.compute_indices(self.indices_process.xci, inputs)
+            out = compute_indices(self, self.indices_process.xci, inputs)
             out_fn = Path(self.workdir) / tasmin.name.replace(
                 "tasmin", "heat_wave_frequency"
             )
@@ -177,7 +146,7 @@ class BCCAQV2HeatWave(SubsetGridPointProcess):
         warnings.filterwarnings("default", category=FutureWarning)
         warnings.filterwarnings("default", category=UserWarning)
 
-        if output_format == "csv":
+        if request.inputs["output_format"][0].data == "csv":
             csv_files, metadata_folder = netcdf_to_csv(
                 output_files,
                 output_folder=Path(self.workdir),
@@ -187,42 +156,12 @@ class BCCAQV2HeatWave(SubsetGridPointProcess):
 
         output_zip = Path(self.workdir) / (output_filename + ".zip")
 
-        def log(message_, percentage_):
-            self.write_log(message_, response, percentage_)
+        def _log(message_, percentage_):
+            write_log(self, message_)
 
-        zip_files(output_zip, output_files, log_function=log, start_percentage=90)
+        zip_files(output_zip, output_files, log_function=_log)
+
         response.outputs["output"].file = output_zip
 
-        self.write_log("Processing finished successfully", response, 99)
+        write_log(self, "Processing finished successfully")
         return response
-
-
-def fix_broken_time_indices(tasmin: Path, tasmax: Path) -> Tuple[Path, Path]:
-    """In a single bccaqv2 dataset, there is an error in the timestamp data.
-
-    2036-10-28 time step coded as 1850-01-01
-    tasmax_day_BCCAQv2+ANUSPLIN300_CESM1-CAM5_historical+rcp85_r1i1p1_19500101-21001231_sub.nc
-    """
-    tasmin_ds = xr.open_dataset(tasmin)
-    tasmax_ds = xr.open_dataset(tasmax)
-
-    def fix(correct_ds, wrong_ds, original_filename):
-        wrong_ds["time"] = correct_ds.time
-        temp_name = original_filename.with_name(original_filename.stem + "_temp")
-        wrong_ds.to_netcdf(temp_name)
-        original_filename.unlink()
-        temp_name.rename(original_filename)
-
-    try:
-        assert_daily(tasmin_ds)
-    except ValueError:
-        fix(tasmax_ds, tasmin_ds, tasmin)
-        return tasmin, tasmax
-
-    try:
-        assert_daily(tasmax_ds)
-    except ValueError:
-        fix(tasmin_ds, tasmax_ds, tasmax)
-        return tasmin, tasmax
-
-    return tasmin, tasmax

--- a/finch/processes/wps_xclim_indices.py
+++ b/finch/processes/wps_xclim_indices.py
@@ -5,10 +5,8 @@ from pywps import ComplexInput, ComplexOutput, FORMATS, LiteralInput
 from pywps.app.Common import Metadata
 from unidecode import unidecode
 
-from .base import FinchProgressBar, FinchProcess
-from .utils import write_log, log_file_path, compute_indices
-
-from .base import FinchProcess
+from .base import FinchProcess, FinchProgressBar
+from .utils import compute_indices, log_file_path, write_log
 
 LOGGER = logging.getLogger("PYWPS")
 

--- a/finch/processes/wps_xclim_indices.py
+++ b/finch/processes/wps_xclim_indices.py
@@ -1,11 +1,14 @@
+import logging
 import os
 
-from finch.processes.base import FinchProgress
-from .base import FinchProcess
 from pywps import ComplexInput, ComplexOutput, FORMATS, LiteralInput
 from pywps.app.Common import Metadata
 from unidecode import unidecode
-import logging
+
+from .base import FinchProgressBar, FinchProcess
+from .utils import write_log, log_file_path, compute_indices
+
+from .base import FinchProcess
 
 LOGGER = logging.getLogger("PYWPS")
 
@@ -15,9 +18,13 @@ def make_xclim_indicator_process(xci):
     attrs = xci.json()
 
     # Sanitize name
-    name = attrs['identifier'].replace('{', '_').replace('}', '_').replace('__', '_')
+    name = attrs["identifier"].replace("{", "_").replace("}", "_").replace("__", "_")
 
-    process_class = type(str(name) + 'Process', (_XclimIndicatorProcess,), {'xci': xci, '__doc__': attrs['abstract']})
+    process_class = type(
+        str(name) + "Process",
+        (_XclimIndicatorProcess,),
+        {"xci": xci, "__doc__": attrs["abstract"]},
+    )
 
     return process_class()
 
@@ -26,37 +33,46 @@ class _XclimIndicatorProcess(FinchProcess):
     """Dummy xclim indicator process class.
 
     Set xci to the xclim indicator in order to have a working class"""
+
     xci = None
 
     def __init__(self):
         """Create a WPS process from an xclim indicator class instance."""
 
         if self.xci is None:
-            raise AttributeError("Use the `make_xclim_indicator_process` function instead.")
+            raise AttributeError(
+                "Use the `make_xclim_indicator_process` function instead."
+            )
 
         attrs = self.xci.json()
 
         outputs = [
-            ComplexOutput('output_netcdf', 'Function output in netCDF',
-                          abstract="The indicator values computed on the original input grid.",
-                          as_reference=True,
-                          supported_formats=[FORMATS.NETCDF, ]  # To support FORMATS.DODS we need to get the URL.
-                          ),
-
-            ComplexOutput('output_log', 'Logging information',
-                          abstract="Collected logs during process run.",
-                          as_reference=True,
-                          supported_formats=[FORMATS.TEXT]),
+            ComplexOutput(
+                "output_netcdf",
+                "Function output in netCDF",
+                abstract="The indicator values computed on the original input grid.",
+                as_reference=True,
+                supported_formats=[
+                    FORMATS.NETCDF,
+                ],  # To support FORMATS.DODS we need to get the URL.
+            ),
+            ComplexOutput(
+                "output_log",
+                "Logging information",
+                abstract="Collected logs during process run.",
+                as_reference=True,
+                supported_formats=[FORMATS.TEXT],
+            ),
         ]
 
-        identifier = attrs['identifier']
-        super(_XclimIndicatorProcess, self).__init__(
+        identifier = attrs["identifier"]
+        super().__init__(
             self._handler,
             identifier=identifier,
-            version='0.1',
-            title=unidecode(attrs['long_name']),
-            abstract=unidecode(attrs['abstract']),
-            inputs=self.load_inputs(eval(attrs['parameters'])),
+            version="0.1",
+            title=unidecode(attrs["long_name"]),
+            abstract=unidecode(attrs["abstract"]),
+            inputs=self.load_inputs(eval(attrs["parameters"])),
             outputs=outputs,
             status_supported=True,
             store_supported=True,
@@ -67,18 +83,18 @@ class _XclimIndicatorProcess(FinchProcess):
         inputs = []
 
         for name, attrs in params.items():
-            if name in ['tas', 'tasmin', 'tasmax', 'pr', 'prsn']:
+            if name in ["tas", "tasmin", "tasmax", "pr", "prsn"]:
                 inputs.append(make_nc_input(name))
-            elif name in ['tn10', 'tn90', 't10', 't90']:
+            elif name in ["tn10", "tn90", "t10", "t90"]:
                 inputs.append(make_nc_input(name))
-            elif name in ['thresh_tasmin', 'thresh_tasmax']:
-                inputs.append(make_thresh(name, attrs['default'], attrs['desc']))
-            elif name in ['thresh', ]:
-                inputs.append(make_thresh(name, attrs['default'], attrs['desc']))
-            elif name in ['freq', ]:
-                inputs.append(make_freq(name, attrs['default']))
-            elif name in ['window', ]:
-                inputs.append(make_window(name, attrs['default'], attrs['desc']))
+            elif name in ["thresh_tasmin", "thresh_tasmax"]:
+                inputs.append(make_thresh(name, attrs["default"], attrs["desc"]))
+            elif name in ["thresh"]:
+                inputs.append(make_thresh(name, attrs["default"], attrs["desc"]))
+            elif name in ["freq"]:
+                inputs.append(make_freq(name, attrs["default"]))
+            elif name in ["window"]:
+                inputs.append(make_window(name, attrs["default"], attrs["desc"]))
             else:
                 # raise NotImplementedError(name)
                 LOGGER.warning("not implemented: {}".format(name))
@@ -86,60 +102,71 @@ class _XclimIndicatorProcess(FinchProcess):
         return inputs
 
     def _handler(self, request, response):
-        self.write_log("Processing started", response, 5)
-        out = self.compute_indices(self.xci, request.inputs)
+        write_log(self, "Processing started")
+        out = compute_indices(self, self.xci, request.inputs)
 
-        out_fn = os.path.join(self.workdir, 'out.nc')
+        out_fn = os.path.join(self.workdir, "out.nc")
 
-        self.write_log("Computing the output netcdf", response, 10)
+        write_log(self, "Computing the output netcdf")
 
-        def write_log(message, percentage):
-            self.write_log(message, response, percentage)
+        def _log(message, percentage):
+            write_log(self, message)
 
-        with FinchProgress(write_log, start_percentage=10, width=15, dt=1):
+        with FinchProgressBar(_log, start_percentage=10, width=15, dt=1):
             out.to_netcdf(out_fn)
 
-        self.write_log("Processing finished successfully", response, 99)
+        write_log(self, "Processing finished successfully")
 
-        response.outputs['output_netcdf'].file = out_fn
-        response.outputs['output_log'].file = self.log_file_path()
+        response.outputs["output_netcdf"].file = out_fn
+        response.outputs["output_log"].file = log_file_path(self)
+
         return response
 
 
-def make_freq(name, default='YS', allowed=('YS', 'MS', 'QS-DEC', 'AS-JUL')):
-    return LiteralInput(name, 'Frequency',
-                        abstract='Resampling frequency',
-                        data_type='string',
-                        min_occurs=0,
-                        max_occurs=1,
-                        default=default,
-                        allowed_values=allowed)
+def make_freq(name, default="YS", allowed=("YS", "MS", "QS-DEC", "AS-JUL")):
+    return LiteralInput(
+        name,
+        "Frequency",
+        abstract="Resampling frequency",
+        data_type="string",
+        min_occurs=0,
+        max_occurs=1,
+        default=default,
+        allowed_values=allowed,
+    )
 
 
-def make_thresh(name, default, abstract=''):
-    return LiteralInput(name, 'threshold',
-                        abstract=abstract,
-                        data_type='string',
-                        min_occurs=0,
-                        max_occurs=1,
-                        default=default,
-                        )
+def make_thresh(name, default, abstract=""):
+    return LiteralInput(
+        name,
+        "threshold",
+        abstract=abstract,
+        data_type="string",
+        min_occurs=0,
+        max_occurs=1,
+        default=default,
+    )
 
 
-def make_window(name, default, abstract=''):
-    return LiteralInput(name, 'window',
-                        abstract=abstract,
-                        data_type='integer',
-                        min_occurs=0,
-                        max_occurs=1,
-                        default=default,
-                        )
+def make_window(name, default, abstract=""):
+    return LiteralInput(
+        name,
+        "window",
+        abstract=abstract,
+        data_type="integer",
+        min_occurs=0,
+        max_occurs=1,
+        default=default,
+    )
 
 
 def make_nc_input(name):
-    return ComplexInput(name, 'Resource',
-                        abstract='NetCDF Files or archive (tar/zip) containing netCDF files.',
-                        metadata=[Metadata('Info')],
-                        min_occurs=1,
-                        max_occurs=1,
-                        supported_formats=[FORMATS.NETCDF])
+    return ComplexInput(
+        name,
+        "Resource",
+        abstract="NetCDF Files or archive (tar/zip) containing netCDF files.",
+        metadata=[Metadata("Info")],
+        min_occurs=1,
+        max_occurs=1,
+        supported_formats=[FORMATS.NETCDF],
+    )

--- a/finch/processes/wps_xsubsetbbox.py
+++ b/finch/processes/wps_xsubsetbbox.py
@@ -75,15 +75,20 @@ class SubsetBboxProcess(FinchProcess):
             store_supported=True,
         )
 
+        self.status_percentage_steps = {
+            "start": 5,
+            "done": 99,
+        }
+
     def _handler(self, request, response):
-        write_log(self, "Processing started")
+        write_log(self, "Processing started", process_step="start")
 
         output_files = finch_subset_bbox(self, request.inputs)
         metalink = make_metalink_output(self, output_files)
 
-        write_log(self, "Processing finished successfully")
-
         response.outputs["output"].file = metalink.files[0].file
         response.outputs["ref"].data = metalink.xml
+
+        write_log(self, "Processing finished successfully", process_step="done")
 
         return response

--- a/finch/processes/wps_xsubsetbbox.py
+++ b/finch/processes/wps_xsubsetbbox.py
@@ -2,18 +2,17 @@ from threading import Lock
 import logging
 
 from pywps import LiteralInput, ComplexInput, ComplexOutput, FORMATS
-from pywps.app.exceptions import ProcessError
-from pywps.inout.outputs import MetaLink4
-from xclim.subset import subset_bbox, subset_gridpoint
 from .wpsio import start_date, end_date, lat0, lat1, lon0, lon1
 
-from finch.processes.subset import SubsetProcess
+from finch.processes.base import FinchProcess
+from finch.processes.utils import make_metalink_output, write_log
+from finch.processes.subset import finch_subset_bbox
 
 
 LOGGER = logging.getLogger("PYWPS")
 
 
-class SubsetBboxProcess(SubsetProcess):
+class SubsetBboxProcess(FinchProcess):
     """Subset a NetCDF file using bounding box geometry."""
 
     def __init__(self):
@@ -60,7 +59,7 @@ class SubsetBboxProcess(SubsetProcess):
             ),
         ]
 
-        super(SubsetBboxProcess, self).__init__(
+        super().__init__(
             self._handler,
             identifier="subset_bbox",
             title="Subset with bounding box",
@@ -76,70 +75,13 @@ class SubsetBboxProcess(SubsetProcess):
             store_supported=True,
         )
 
-    def subset(
-        self, wps_inputs, response, start_percentage=10, end_percentage=85, threads=1
-    ) -> MetaLink4:
-        lon0 = wps_inputs["lon0"][0].data
-        lat0 = wps_inputs["lat0"][0].data
-        lon1 = self.get_input_or_none(wps_inputs, "lon1")
-        lat1 = self.get_input_or_none(wps_inputs, "lat1")
-        start = self.get_input_or_none(wps_inputs, "start_date")
-        end = self.get_input_or_none(wps_inputs, "end_date")
-        variables = [r.data for r in wps_inputs.get("variable", [])]
-
-        nones = [lat1 is None, lon1 is None]
-        if any(nones) and not all(nones):
-            raise ProcessError("lat1 and lon1 must be both omitted or provided")
-
-        n_files = len(wps_inputs["resource"])
-        count = 0
-
-        lock = Lock()
-
-        def _subset_function(resource):
-            nonlocal count
-
-            # if not subsetting by time, it's not necessary to decode times
-            time_subset = start is not None or end is not None
-            dataset = self.try_opendap(resource, decode_times=time_subset)
-
-            with lock:
-                count += 1
-                percentage = start_percentage + int(
-                    (count - 1) / n_files * (end_percentage - start_percentage)
-                )
-                self.write_log(
-                    f"Subsetting file {count} of {n_files}",
-                    response=response,
-                    percentage=percentage,
-                )
-
-            dataset = dataset[variables] if variables else dataset
-            if lat1 is None and lon1 is None:
-                return subset_gridpoint(
-                    dataset, lon=lon0, lat=lat0, start_date=start, end_date=end
-                )
-            else:
-                return subset_bbox(
-                    dataset,
-                    lon_bnds=[lon0, lon1],
-                    lat_bnds=[lat0, lat1],
-                    start_date=start,
-                    end_date=end,
-                )
-
-        metalink = self.subset_resources(
-            wps_inputs["resource"], _subset_function, threads=threads
-        )
-
-        return metalink
-
     def _handler(self, request, response):
-        self.write_log("Processing started", response, 5)
+        write_log(self, "Processing started")
 
-        metalink = self.subset(request.inputs, response)
+        output_files = finch_subset_bbox(self, request.inputs)
+        metalink = make_metalink_output(self, output_files)
 
-        self.write_log("Processing finished successfully", response, 99)
+        write_log(self, "Processing finished successfully")
 
         response.outputs["output"].file = metalink.files[0].file
         response.outputs["ref"].data = metalink.xml

--- a/finch/processes/wps_xsubsetbbox_bccaqv2.py
+++ b/finch/processes/wps_xsubsetbbox_bccaqv2.py
@@ -82,9 +82,21 @@ class SubsetBboxBCCAQV2Process(FinchProcess):
             store_supported=True,
         )
 
+        self.status_percentage_steps = {
+            "start": 5,
+            "subset": 7,
+            "convert_to_csv": 90,
+            "zip_outputs": 95,
+            "done": 99,
+        }
+
     def _handler(self, request: WPSRequest, response: ExecuteResponse):
-        self.percentage = 5
-        write_log(self, "Processing started")
+
+        convert_to_csv = request.inputs["output_format"][0].data == "csv"
+        if not convert_to_csv:
+            del self.status_percentage_steps["convert_to_csv"]
+
+        write_log(self, "Processing started", process_step="start")
 
         output_filename = make_output_filename(self, request.inputs)
 
@@ -94,8 +106,7 @@ class SubsetBboxBCCAQV2Process(FinchProcess):
         rcp = single_input_or_none(request.inputs, "rcp")
         request.inputs = get_bccaqv2_inputs(request.inputs, variable=variable, rcp=rcp)
 
-        self.percentage = 7
-        write_log(self, "Running subset")
+        write_log(self, "Running subset", process_step="subset")
 
         output_files = finch_subset_bbox(self, request.inputs)
 
@@ -103,9 +114,9 @@ class SubsetBboxBCCAQV2Process(FinchProcess):
             message = "No data was produced when subsetting using the provided bounds."
             raise ProcessError(message)
 
-        write_log(self, "Subset done, creating zip file")
+        if convert_to_csv:
+            write_log(self, "Converting outputs to csv", process_step="convert_to_csv")
 
-        if request.inputs["output_format"][0].data == "csv":
             csv_files, metadata_folder = netcdf_to_csv(
                 output_files,
                 output_folder=Path(self.workdir),
@@ -113,14 +124,16 @@ class SubsetBboxBCCAQV2Process(FinchProcess):
             )
             output_files = csv_files + [metadata_folder]
 
+        write_log(self, "Zipping outputs", process_step="zip_outputs")
+
         output_zip = Path(self.workdir) / (output_filename + ".zip")
 
-        def _log(message_, percentage_):
-            write_log(self, message_)
+        def _log(message, percentage):
+            write_log(self, message, subtask_percentage=percentage)
 
         zip_files(output_zip, output_files, log_function=_log)
 
         response.outputs["output"].file = output_zip
 
-        write_log(self, "Processing finished successfully")
+        write_log(self, "Processing finished successfully", process_step="done")
         return response

--- a/finch/processes/wps_xsubsetpoint.py
+++ b/finch/processes/wps_xsubsetpoint.py
@@ -67,8 +67,13 @@ class SubsetGridPointProcess(FinchProcess):
             store_supported=True,
         )
 
+        self.status_percentage_steps = {
+            "start": 5,
+            "done": 99,
+        }
+
     def _handler(self, request, response):
-        write_log(self, "Processing started")
+        write_log(self, "Processing started", process_step="start")
 
         output_files = finch_subset_gridpoint(self, request.inputs)
         metalink = make_metalink_output(self, output_files)
@@ -76,6 +81,6 @@ class SubsetGridPointProcess(FinchProcess):
         response.outputs["output"].file = metalink.files[0].file
         response.outputs["ref"].data = metalink.xml
 
-        write_log(self, "Processing finished successfully")
+        write_log(self, "Processing finished successfully", process_step="done")
 
         return response

--- a/finch/processes/wps_xsubsetpoint.py
+++ b/finch/processes/wps_xsubsetpoint.py
@@ -1,14 +1,12 @@
-from threading import Lock
+from pywps import ComplexInput, ComplexOutput, FORMATS, LiteralInput
 
-import xarray as xr
-from pywps import LiteralInput, ComplexInput, ComplexOutput, FORMATS
-from pywps.inout.outputs import MetaLink4
-from xclim.subset import subset_gridpoint
-from .wpsio import start_date, end_date, lon, lat
-from finch.processes.subset import SubsetProcess
+from .base import FinchProcess
+from .subset import finch_subset_gridpoint
+from .utils import make_metalink_output, write_log
+from .wpsio import end_date, lat, lon, start_date
 
 
-class SubsetGridPointProcess(SubsetProcess):
+class SubsetGridPointProcess(FinchProcess):
     """Subset a NetCDF file grid cells using a list of coordinates."""
 
     def __init__(self):
@@ -53,7 +51,7 @@ class SubsetGridPointProcess(SubsetProcess):
             ),
         ]
 
-        super(SubsetGridPointProcess, self).__init__(
+        super().__init__(
             self._handler,
             identifier="subset_gridpoint",
             title="Subset with a grid point",
@@ -69,64 +67,15 @@ class SubsetGridPointProcess(SubsetProcess):
             store_supported=True,
         )
 
-    def subset(
-        self, wps_inputs, response, start_percentage=10, end_percentage=85, threads=1
-    ) -> MetaLink4:
-        longitudes = [float(lon) for lon in wps_inputs["lon"][0].data.split(",")]
-        latitudes = [float(lat) for lat in wps_inputs["lat"][0].data.split(",")]
-        start = self.get_input_or_none(wps_inputs, "start_date")
-        end = self.get_input_or_none(wps_inputs, "end_date")
-        variables = [r.data for r in wps_inputs.get("variable", [])]
-
-        n_files = len(wps_inputs["resource"])
-        count = 0
-
-        lock = Lock()
-
-        def _subset_function(resource):
-            nonlocal count
-
-            # if not subsetting by time, it's not necessary to decode times
-            time_subset = start is not None or end is not None
-            dataset = self.try_opendap(resource, decode_times=time_subset)
-
-            with lock:
-                count += 1
-
-                percentage = start_percentage + int(
-                    (count - 1) / n_files * (end_percentage - start_percentage)
-                )
-                self.write_log(
-                    f"Subsetting file {count} of {n_files}", response, percentage
-                )
-
-            dataset = dataset[variables] if variables else dataset
-
-            subsets = []
-            for longitude, latitude in zip(longitudes, latitudes):
-                subset = subset_gridpoint(
-                    dataset, lon=longitude, lat=latitude, start_date=start, end_date=end
-                )
-                subsets.append(subset)
-
-            output = xr.concat(subsets, dim="region")
-
-            return output
-
-        metalink = self.subset_resources(
-            wps_inputs["resource"], _subset_function, threads=threads
-        )
-
-        return metalink
-
     def _handler(self, request, response):
-        self.write_log("Processing started", response, 5)
+        write_log(self, "Processing started")
 
-        metalink = self.subset(request.inputs, response)
-
-        self.write_log("Processing finished successfully", response, 99)
+        output_files = finch_subset_gridpoint(self, request.inputs)
+        metalink = make_metalink_output(self, output_files)
 
         response.outputs["output"].file = metalink.files[0].file
         response.outputs["ref"].data = metalink.xml
+
+        write_log(self, "Processing finished successfully")
 
         return response

--- a/finch/processes/wps_xsubsetpoint_bccaqv2.py
+++ b/finch/processes/wps_xsubsetpoint_bccaqv2.py
@@ -1,16 +1,18 @@
 from pathlib import Path
-from pywps.response.execute import ExecuteResponse
-from pywps.app.exceptions import ProcessError
+
+from pywps import ComplexOutput, FORMATS, LiteralInput
 from pywps.app import WPSRequest
-from .wpsio import start_date, end_date
-from pywps import LiteralInput, ComplexOutput, FORMATS, configuration
+from pywps.app.exceptions import ProcessError
+from pywps.response.execute import ExecuteResponse
 
-from finch.processes import SubsetGridPointProcess
-from finch.processes.subset import SubsetProcess
-from finch.processes.utils import get_bccaqv2_inputs, netcdf_to_csv, zip_files
+from .base import FinchProcess
+from .bccaqv2 import get_bccaqv2_inputs, make_output_filename
+from .subset import finch_subset_gridpoint
+from .utils import netcdf_to_csv, single_input_or_none, write_log, zip_files
+from .wpsio import end_date, start_date
 
 
-class SubsetGridPointBCCAQV2Process(SubsetGridPointProcess):
+class SubsetGridPointBCCAQV2Process(FinchProcess):
     """Subset a NetCDF file grid cells using a list of coordinates."""
 
     def __init__(self):
@@ -93,8 +95,7 @@ class SubsetGridPointBCCAQV2Process(SubsetGridPointProcess):
             )
         ]
 
-        SubsetProcess.__init__(
-            self,
+        super().__init__(
             self._handler,
             identifier="subset_ensemble_BCCAQv2",
             title="Subset of BCCAQv2 datasets grid cells using a list of coordinates",
@@ -111,12 +112,13 @@ class SubsetGridPointBCCAQV2Process(SubsetGridPointProcess):
         )
 
     def _handler(self, request: WPSRequest, response: ExecuteResponse):
-        self.write_log("Processing started", response, 5)
+        self.percentage = 5
+        write_log(self, "Processing started")
 
         # Temporary backward-compatibility adjustment.
         # Remove me when lon0 and lat0 are removed
         lon, lat, lon0, lat0 = [
-            self.get_input_or_none(request.inputs, var)
+            single_input_or_none(request.inputs, var)
             for var in "lon lat lon0 lat0".split()
         ]
         if not (lon and lat or lon0 and lat0):
@@ -125,38 +127,26 @@ class SubsetGridPointBCCAQV2Process(SubsetGridPointProcess):
         request.inputs.setdefault("lat", request.inputs.get("lat0"))
         # End of 'remove me'
 
-        # Build output filename
-        variable = self.get_input_or_none(request.inputs, "variable")
-        rcp = self.get_input_or_none(request.inputs, "rcp")
-        lat = self.get_input_or_none(request.inputs, "lat").split(",")[0]
-        lon = self.get_input_or_none(request.inputs, "lon").split(",")[0]
-        output_format = request.inputs["output_format"][0].data
-        output_filename = f"BCCAQv2_subset_grid_cells_{float(lat):.3f}_{float(lon):.3f}"
+        output_filename = make_output_filename(self, request.inputs)
 
-        self.write_log("Fetching BCCAQv2 datasets", response, 6)
-        request.inputs = get_bccaqv2_inputs(request.inputs, variable, rcp)
+        write_log(self, "Fetching BCCAQv2 datasets")
 
-        self.write_log("Running subset", response, 7)
+        variable = single_input_or_none(request.inputs, "variable")
+        rcp = single_input_or_none(request.inputs, "rcp")
+        request.inputs = get_bccaqv2_inputs(request.inputs, variable=variable, rcp=rcp)
 
-        threads = int(configuration.get_config_value("finch", "subset_threads"))
+        self.percentage = 7
+        write_log(self, "Running subset")
 
-        metalink = self.subset(
-            request.inputs,
-            response,
-            start_percentage=7,
-            end_percentage=90,
-            threads=threads,
-        )
+        output_files = finch_subset_gridpoint(self, request.inputs)
 
-        if not metalink.files:
+        if not output_files:
             message = "No data was produced when subsetting using the provided bounds."
             raise ProcessError(message)
 
-        self.write_log("Subset done, creating zip file", response)
+        write_log(self, "Subset done, creating zip file")
 
-        output_files = [mf.file for mf in metalink.files]
-
-        if output_format == "csv":
+        if request.inputs["output_format"][0].data == "csv":
             csv_files, metadata_folder = netcdf_to_csv(
                 output_files,
                 output_folder=Path(self.workdir),
@@ -166,11 +156,12 @@ class SubsetGridPointBCCAQV2Process(SubsetGridPointProcess):
 
         output_zip = Path(self.workdir) / (output_filename + ".zip")
 
-        def log(message_, percentage_):
-            self.write_log(message_, response, percentage_)
+        def _log(message_, percentage_):
+            write_log(self, message_)
 
-        zip_files(output_zip, output_files, log_function=log, start_percentage=90)
+        zip_files(output_zip, output_files, log_function=_log)
+
         response.outputs["output"].file = output_zip
 
-        self.write_log("Processing finished successfully", response, 99)
+        write_log(self, "Processing finished successfully")
         return response

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,17 +6,16 @@ import numpy as np
 import pandas as pd
 from pywps import configuration
 
+from finch.processes.bccaqv2 import get_bccaqv2_opendap_datasets
 from finch.processes.utils import (
-    get_bccaqv2_opendap_datasets,
     netcdf_to_csv,
     zip_files,
     is_opendap_url,
 )
-import pytest
 from unittest import mock
 
 
-@mock.patch("finch.processes.utils.TDSCatalog")
+@mock.patch("finch.processes.bccaqv2.TDSCatalog")
 def test_get_opendap_datasets_bccaqv2(mock_tdscatalog):
     names = [
         "tasmin_day_BCCAQv2+ANUSPLIN300_CNRM-CM5_historical+rcp85_r1i1p1_19500101-21001231.nc",

--- a/tests/test_wps_bccaqv2_subset.py
+++ b/tests/test_wps_bccaqv2_subset.py
@@ -7,14 +7,12 @@ import xarray as xr
 from netCDF4 import Dataset
 
 from tests.utils import wps_literal_input, execute_process
-from finch.processes.wps_xsubsetpoint_bccaqv2 import SubsetGridPointBCCAQV2Process
-from finch.processes.wps_xsubsetbbox_bccaqv2 import SubsetBboxBCCAQV2Process
 
 
 @pytest.fixture
 def mock_local_datasets(monkeypatch):
     from pywps.configuration import CONFIG
-    from finch.processes import utils
+    from finch.processes import bccaqv2
 
     CONFIG.set("finch", "bccaqv2_url", "/mock_local/path")
 
@@ -23,7 +21,7 @@ def mock_local_datasets(monkeypatch):
     )
 
     monkeypatch.setattr(
-        utils, "get_bccaqv2_local_files_datasets", lambda *args: [f"{test_data}"]
+        bccaqv2, "get_bccaqv2_local_files_datasets", lambda *args: [f"{test_data}"]
     )
 
 


### PR DESCRIPTION
## Overview

This PR fixes #62 

Apologies if this PR is large, but it's mainly moving stuff around to compose processes with functions and reduce inheritance.

It's been a while since I realized that my decision to use inheritance to improve code reuse was a bad idea. Our next step is adding more bccaqv2 processes and I felt like this was a good time to do this refactor.

The bccaqv2 processes were too coupled to their parents, and the inheritance was getting a bit too deep.

The previous inheritance went from 
`pywps.Process -> finch.FinchProcess -> finch.SubsetProcess ->finch.SubsetGridPointProcess -> finch.SubsetBboxBCCAQV2Process` 
to 
`pywps.Process -> finch.FinchProcess -> finch.SubsetBboxBCCAQV2Process`

Unit tests all pass, and I'm currently testing on a deployed server...