### PR TITLE
update usage notebook for new jenkins build

### DIFF
--- a/docs/source/notebooks/finch-usage.ipynb
+++ b/docs/source/notebooks/finch-usage.ipynb
@@ -81,8 +81,8 @@
      "text": [
       "ProcessSucceeded\n",
       "frost_daysResponse(\n",
-      "    output_netcdf='https://pavics.ouranos.ca/wpsoutputs/1bb76e5e-827a-11e9-be8a-0242ac19000f/out.nc',\n",
-      "    output_log='https://pavics.ouranos.ca/wpsoutputs/1bb76e5e-827a-11e9-be8a-0242ac19000f/log.txt'\n",
+      "    output_netcdf='https://pavics.ouranos.ca/wpsoutputs/e8afbb04-42d3-11ea-9531-0242ac12000b/out.nc',\n",
+      "    output_log='https://pavics.ouranos.ca/wpsoutputs/e8afbb04-42d3-11ea-9531-0242ac12000b/log.txt'\n",
       ")\n"
      ]
     }
@@ -116,6 +116,35 @@
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<pre>&lt;xarray.Dataset&gt;\n",
+       "Dimensions:     (lat: 6, lon: 7, time: 20)\n",
+       "Coordinates:\n",
+       "    height      float64 ...\n",
+       "  * time        (time) object 2046-01-01 00:00:00 ... 2065-01-01 00:00:00\n",
+       "  * lat         (lat) float64 42.68 46.39 50.1 53.81 57.52 61.23\n",
+       "  * lon         (lon) float64 281.2 285.0 288.8 292.5 296.2 300.0 303.8\n",
+       "Data variables:\n",
+       "    frost_days  (time, lat, lon) timedelta64[ns] ...\n",
+       "Attributes:\n",
+       "    comment:        Spinup: restart files from end of experiment 20C3M (corre...\n",
+       "    title:          MIUB  model output prepared for IPCC Fourth Assessment SR...\n",
+       "    cmor_version:   0.96\n",
+       "    institution:    MIUB (University of Bonn, Bonn, Germany)\n",
+       "    source:         ECHO-G(1999): atmosphere: ECHAM4 (T30L19) with partial se...\n",
+       "    contact:        Stephanie Legutke (legutke@dkrz.de), Seung-Ki Min(skmin@u...\n",
+       "    references:     ECHAM4: E. Roeckner et al., 1996, The atmospheric general...\n",
+       "    experiment_id:  SRES A2 experiment\n",
+       "    realization:    1\n",
+       "    directory:      /ipcc/sresa2/atm/da/\n",
+       "    table_id:       Table A2 (17 November 2004)\n",
+       "    calendar:       360_day\n",
+       "    project_id:     IPCC Fourth Assessment\n",
+       "    Conventions:    CF-1.0\n",
+       "    id:             pcmdi.ipcc4.miub_echo_g.sresa2.run1.atm.da\n",
+       "    history:        Mon Aug  1 11:43:58 2011: ncks -4 -L 7 -d lat,42.0,64.0 -...\n",
+       "    NCO:            4.0.9</pre>"
+      ],
       "text/plain": [
        "<xarray.Dataset>\n",
        "Dimensions:     (lat: 6, lon: 7, time: 20)\n",
@@ -179,6 +208,35 @@
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<pre>&lt;xarray.Dataset&gt;\n",
+       "Dimensions:     (lat: 6, lon: 7, time: 20)\n",
+       "Coordinates:\n",
+       "    height      float64 ...\n",
+       "  * time        (time) object 2046-01-01 00:00:00 ... 2065-01-01 00:00:00\n",
+       "  * lat         (lat) float64 42.68 46.39 50.1 53.81 57.52 61.23\n",
+       "  * lon         (lon) float64 281.2 285.0 288.8 292.5 296.2 300.0 303.8\n",
+       "Data variables:\n",
+       "    frost_days  (time, lat, lon) timedelta64[ns] ...\n",
+       "Attributes:\n",
+       "    comment:        Spinup: restart files from end of experiment 20C3M (corre...\n",
+       "    title:          MIUB  model output prepared for IPCC Fourth Assessment SR...\n",
+       "    cmor_version:   0.96\n",
+       "    institution:    MIUB (University of Bonn, Bonn, Germany)\n",
+       "    source:         ECHO-G(1999): atmosphere: ECHAM4 (T30L19) with partial se...\n",
+       "    contact:        Stephanie Legutke (legutke@dkrz.de), Seung-Ki Min(skmin@u...\n",
+       "    references:     ECHAM4: E. Roeckner et al., 1996, The atmospheric general...\n",
+       "    experiment_id:  SRES A2 experiment\n",
+       "    realization:    1\n",
+       "    directory:      /ipcc/sresa2/atm/da/\n",
+       "    table_id:       Table A2 (17 November 2004)\n",
+       "    calendar:       360_day\n",
+       "    project_id:     IPCC Fourth Assessment\n",
+       "    Conventions:    CF-1.0\n",
+       "    id:             pcmdi.ipcc4.miub_echo_g.sresa2.run1.atm.da\n",
+       "    history:        Mon Aug  1 11:43:58 2011: ncks -4 -L 7 -d lat,42.0,64.0 -...\n",
+       "    NCO:            4.0.9</pre>"
+      ],
       "text/plain": [
        "<xarray.Dataset>\n",
        "Dimensions:     (lat: 6, lon: 7, time: 20)\n",
@@ -259,7 +317,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Overview

This PR fixes NA

Changes:
Small adjustement to notebook (output windows). 

When trying to deploy a new build  https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/tree/add-threddsclient-bokeh-to-jupyter-env we see minor changes in notebook output (e.g. html text versus plain .. ordered dict versus dict in attribute output).  Mostly likely due to xarray upgrade to 0.14.



## Related Issue / Discussion

## Additional Information

Links to other issues or sources.

Same issues for other notebooks on pavics-sdi used for the jenkins tests
https://github.com/Ouranosinc/pavics-sdi/pull/149
