### PR TITLE
Fix ensemble computation

### DIFF
--- a/finch/processes/ensemble_utils.py
+++ b/finch/processes/ensemble_utils.py
@@ -441,6 +441,13 @@ def make_file_groups(files_list: List[Path]) -> List[Dict[str, Path]]:
 
 def make_ensemble(files: List[Path], percentiles: List[int]) -> None:
     ensemble = ensembles.create_ensemble(files)
+    # Depending on the datasets, I've found that writing the netcdf could hang
+    # if the dataset was not loaded explicitely previously... Not sure why.
+    # The datasets should be pretty small when computing the ensembles, so this is
+    # a best effort at working around what looks like a bug in either xclim or xarray.
+    # The xarray documentation mentions: 'this method can be necessary when working
+    # with many file objects on disk.'
+    ensemble.load()
     # make sure we have data starting in 1950
     ensemble = ensemble.sel(time=(ensemble.time.dt.year >= 1950))
     ensemble_percentiles = ensembles.ensemble_percentiles(ensemble, values=percentiles)

--- a/finch/processes/ensemble_utils.py
+++ b/finch/processes/ensemble_utils.py
@@ -405,16 +405,16 @@ def make_file_groups(files_list: List[Path]) -> List[Dict[str, Path]]:
 
 def make_ensemble(files: List[Path], percentiles: List[int]) -> None:
     ensemble = ensembles.create_ensemble(files)
+    # make sure we have data starting in 1950
+    ensemble = ensemble.sel(time=(ensemble.time.dt.year >= 1950))
+    ensemble_percentiles = ensembles.ensemble_percentiles(ensemble, values=percentiles)
     # Depending on the datasets, I've found that writing the netcdf could hang
     # if the dataset was not loaded explicitely previously... Not sure why.
     # The datasets should be pretty small when computing the ensembles, so this is
     # a best effort at working around what looks like a bug in either xclim or xarray.
     # The xarray documentation mentions: 'this method can be necessary when working
     # with many file objects on disk.'
-    ensemble.load()
-    # make sure we have data starting in 1950
-    ensemble = ensemble.sel(time=(ensemble.time.dt.year >= 1950))
-    ensemble_percentiles = ensembles.ensemble_percentiles(ensemble, values=percentiles)
+    ensemble_percentiles.load()
 
     return ensemble_percentiles
 

--- a/finch/processes/utils.py
+++ b/finch/processes/utils.py
@@ -511,7 +511,7 @@ def make_tasmin_tasmax_pairs(
 
 def fix_broken_time_index(ds: xr.Dataset):
     """Fix for a single broken index in a specific file"""
-    if not "time" in ds.dims:
+    if "time" not in ds.dims:
         return
 
     wrong_value = cftime.DatetimeNoLeap(year=1850, month=1, day=1, hour=0)

--- a/finch/processes/utils.py
+++ b/finch/processes/utils.py
@@ -527,10 +527,13 @@ def fix_broken_time_index(ds: xr.Dataset):
     if wrong_id == 0 or wrong_id == len(ds.time) - 1:
         return
 
-    is_daily = time_dim[wrong_id + 1] - time_dim[wrong_id - 1] == timedelta(days=2)
+    daily_gap = 1.0 if times_are_encoded else timedelta(days=1)
+
+    is_daily = time_dim[wrong_id + 1] - time_dim[wrong_id - 1] == daily_gap * 2
+
     if is_daily:
         fixed_time = time_dim
-        fixed_time[wrong_id] = time_dim[wrong_id - 1] + timedelta(days=1)
+        fixed_time[wrong_id] = time_dim[wrong_id - 1] + daily_gap
         ds["time"] = fixed_time
 
 

--- a/finch/processes/utils.py
+++ b/finch/processes/utils.py
@@ -513,10 +513,14 @@ def fix_broken_time_index(ds: xr.Dataset):
     """Fix for a single broken index in a specific file"""
     if not "time" in ds.dims:
         return
+
+    wrong_value = cftime.DatetimeNoLeap(year=1850, month=1, day=1, hour=0)
+    times_are_encoded = "units" in ds.time.attrs
+    if times_are_encoded:
+        wrong_value = 0
+
     time_dim = ds.time.values
-    wrong_id = np.argwhere(
-        time_dim == cftime.DatetimeNoLeap(year=1850, month=1, day=1, hour=0)
-    )
+    wrong_id = np.argwhere(time_dim == wrong_value)
     if not wrong_id:
         return
     wrong_id = wrong_id[0, 0]

--- a/finch/processes/utils.py
+++ b/finch/processes/utils.py
@@ -514,13 +514,16 @@ def fix_broken_time_index(ds: xr.Dataset):
     if "time" not in ds.dims:
         return
 
-    wrong_value = cftime.DatetimeNoLeap(year=1850, month=1, day=1, hour=0)
-    times_are_encoded = "units" in ds.time.attrs
-    if times_are_encoded:
-        wrong_value = 0
-
     time_dim = ds.time.values
-    wrong_id = np.argwhere(time_dim == wrong_value)
+    times_are_encoded = "units" in ds.time.attrs
+
+    if times_are_encoded:
+        wrong_id = np.argwhere(np.isclose(time_dim, 0))
+    else:
+        wrong_id = np.argwhere(
+            time_dim == cftime.DatetimeNoLeap(year=1850, month=1, day=1, hour=0)
+        )
+
     if not wrong_id:
         return
     wrong_id = wrong_id[0, 0]
@@ -534,7 +537,9 @@ def fix_broken_time_index(ds: xr.Dataset):
     if is_daily:
         fixed_time = time_dim
         fixed_time[wrong_id] = time_dim[wrong_id - 1] + daily_gap
+        attrs = ds.time.attrs
         ds["time"] = fixed_time
+        ds.time.attrs = attrs
 
 
 def dataset_to_netcdf(

--- a/finch/processes/wps_bccaqv2_heatwave.py
+++ b/finch/processes/wps_bccaqv2_heatwave.py
@@ -9,7 +9,11 @@ from pywps.app.exceptions import ProcessError
 from pywps.response.execute import ExecuteResponse
 from xclim.atmos import heat_wave_frequency
 
-from .ensemble_utils import fix_broken_time_indices, get_datasets, make_output_filename
+from . import wpsio
+from .ensemble_utils import (
+    get_datasets,
+    make_output_filename,
+)
 from .subset import finch_subset_gridpoint
 from .utils import (
     compute_indices,
@@ -19,9 +23,8 @@ from .utils import (
     write_log,
     zip_files,
 )
-from .wps_base import FinchProcess, make_xclim_indicator_process, make_nc_input
+from .wps_base import FinchProcess, make_nc_input, make_xclim_indicator_process
 from .wps_xclim_indices import XclimIndicatorBase
-from . import wpsio
 
 LOGGER = logging.getLogger("PYWPS")
 
@@ -140,8 +143,6 @@ class BCCAQV2HeatWave(FinchProcess):
                 f"Computing indices for file {n + 1} of {n_pairs}",
                 subtask_percentage=n * 100 // n_pairs,
             )
-
-            tasmin, tasmax = fix_broken_time_indices(tasmin, tasmax)
 
             compute_inputs = [i.identifier for i in self.indices_process.inputs]
             inputs = {k: v for k, v in request.inputs.items() if k in compute_inputs}

--- a/tests/test_wps_xsubsetpoint.py
+++ b/tests/test_wps_xsubsetpoint.py
@@ -1,3 +1,4 @@
+import pytest
 from pywps import Service
 from pywps.tests import assert_response_success, client_for
 import xarray as xr
@@ -30,6 +31,7 @@ def test_wps_xsubsetpoint(netcdf_datasets):
     assert ds.lon == 3
 
 
+@pytest.mark.online
 def test_thredds():
     import lxml.etree
 


### PR DESCRIPTION
## Overview

 - add `.load()` to ensemble computation:
```
    # Depending on the datasets, I've found that writing the netcdf could hang
    # if the dataset was not loaded explicitely previously... Not sure why.
    # The datasets should be pretty small when computing the ensembles, so this is
    # a best effort at working around what looks like a bug in either xclim or xarray.
    # The xarray documentation mentions: 'this method can be necessary when working
    # with many file objects on disk.'
    ensemble.load()
```
 - Fix the broken time index in this dataset `tasmax_day_BCCAQv2+ANUSPLIN300_CESM1-CAM5_historical+rcp85_r1i1p1_19500101-21001231` when writing to disk. This ensures that it's called in all the processes. Initially, it was fixed only when tasmax and tasmin were used in heat wave computations.

Edit: added demonstration of broken time index:
```python
>>> import xarray as xr
>>> ds = xr.open_dataset('https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/pcic/BCCAQv2/tasmax_day_BCCAQv2+ANUSPLIN300_CESM1-CAM5_historical+rcp85_r1i1p1_19500101-21001231.nc')
>>> ds.time[31688:31693].values
array([cftime.DatetimeNoLeap(2036-10-26 12:00:00), 
       cftime.DatetimeNoLeap(2036-10-27 12:00:00),
       cftime.DatetimeNoLeap(1850-01-01 00:00:00),
       cftime.DatetimeNoLeap(2036-10-29 12:00:00),
       cftime.DatetimeNoLeap(2036-10-30 12:00:00)], dtype=object)
>>> ds.time[31690].values 
array(cftime.DatetimeNoLeap(1850-01-01 00:00:00), dtype=object)
```