### PR TITLE
Allow for subset_gridpoint with multiple lons and lats, blacken

### DIFF
--- a/finch/processes/wpsio.py
+++ b/finch/processes/wpsio.py
@@ -1,16 +1,15 @@
 """Module storing inputs and outputs used in multiple processes. """
 
+import json
 from copy import deepcopy
 from typing import Union
-import json
 
-from pywps import ComplexInput, ComplexOutput, FORMATS, LiteralInput
+from pywps import FORMATS, ComplexInput, ComplexOutput, LiteralInput
 from pywps.inout.literaltypes import AnyValue
+from xclim.core.options import CHECK_MISSING, MISSING_METHODS, MISSING_OPTIONS, OPTIONS
 
-from .constants import ALLOWED_MODEL_NAMES, ALL_24_MODELS
+from .constants import ALL_24_MODELS, ALLOWED_MODEL_NAMES
 from .utils import PywpsInput, PywpsOutput
-
-from xclim.core.options import MISSING_METHODS, OPTIONS, MISSING_OPTIONS, CHECK_MISSING
 
 
 def copy_io(
@@ -57,6 +56,7 @@ lon = LiteralInput(
     abstract="Longitude coordinate. Accepts a comma separated list of floats for multiple grid cells.",
     data_type="string",
     min_occurs=1,
+    max_occurs=100
 )
 
 lat = LiteralInput(
@@ -65,6 +65,7 @@ lat = LiteralInput(
     abstract="Latitude coordinate. Accepts a comma separated list of floats for multiple grid cells.",
     data_type="string",
     min_occurs=1,
+    max_occurs=100
 )
 
 lon0 = LiteralInput(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 cftime
 pywps>=4.2.0,<4.3
 xclim~=0.21.0
+xarray>=0.14
 clisops==0.5.0
 geopandas
 jinja2

--- a/tests/test_wps_xsubset_bbox.py
+++ b/tests/test_wps_xsubset_bbox.py
@@ -1,10 +1,7 @@
-from pathlib import Path
-
 import numpy as np
-import pytest
+import xarray as xr
 from pywps import Service
 from pywps.tests import assert_response_success, client_for
-import xarray as xr
 
 from finch.processes import SubsetBboxProcess
 


### PR DESCRIPTION
## Overview

This PR fixes #127

Changes:

* Added support for a list of `lons` and `lats` to be supplied to the `subset-gridpoint`

## Related Issue / Discussion

## Additional Information

Links to other issues or sources.
