### PR TITLE
notebooks: run make refresh-notebooks to fix make test-notebooks

### DIFF
--- a/docs/source/notebooks/dap_subset.ipynb
+++ b/docs/source/notebooks/dap_subset.ipynb
@@ -15,7 +15,14 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-01-26T14:55:29.642346Z",
+     "iopub.status.busy": "2021-01-26T14:55:29.641850Z",
+     "iopub.status.idle": "2021-01-26T14:55:31.250468Z",
+     "shell.execute_reply": "2021-01-26T14:55:31.249874Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -37,7 +44,14 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-01-26T14:55:31.254934Z",
+     "iopub.status.busy": "2021-01-26T14:55:31.253249Z",
+     "iopub.status.idle": "2021-01-26T14:55:32.284849Z",
+     "shell.execute_reply": "2021-01-26T14:55:32.285321Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -106,7 +120,7 @@
        "    NCO:            4.0.9"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -120,7 +134,14 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-01-26T14:55:32.303130Z",
+     "iopub.status.busy": "2021-01-26T14:55:32.302416Z",
+     "iopub.status.idle": "2021-01-26T14:55:32.306163Z",
+     "shell.execute_reply": "2021-01-26T14:55:32.305668Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -128,7 +149,7 @@
        "{'lat': 1, 'lon': 2, 'time': slice(5040, 6840, None)}"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -163,7 +184,14 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-01-26T14:55:32.613540Z",
+     "iopub.status.busy": "2021-01-26T14:55:32.613069Z",
+     "iopub.status.idle": "2021-01-26T14:55:32.622637Z",
+     "shell.execute_reply": "2021-01-26T14:55:32.622116Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -218,7 +246,7 @@
        "    NCO:            4.0.9"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -237,7 +265,14 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-01-26T14:55:32.989774Z",
+     "iopub.status.busy": "2021-01-26T14:55:32.989299Z",
+     "iopub.status.idle": "2021-01-26T14:55:33.330756Z",
+     "shell.execute_reply": "2021-01-26T14:55:33.331295Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -298,7 +333,7 @@
        "    NCO:            4.0.9"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -317,7 +352,14 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-01-26T14:55:33.668934Z",
+     "iopub.status.busy": "2021-01-26T14:55:33.668392Z",
+     "iopub.status.idle": "2021-01-26T14:55:34.212332Z",
+     "shell.execute_reply": "2021-01-26T14:55:34.211787Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -380,7 +422,7 @@
        "    NCO:            4.0.9"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -392,7 +434,14 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-01-26T14:55:34.217303Z",
+     "iopub.status.busy": "2021-01-26T14:55:34.216797Z",
+     "iopub.status.idle": "2021-01-26T14:55:34.220044Z",
+     "shell.execute_reply": "2021-01-26T14:55:34.219604Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -400,7 +449,7 @@
        "{'lat': 1, 'lon': 2, 'time': slice(5040, 6840, None)}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -412,7 +461,14 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-01-26T14:55:34.227572Z",
+     "iopub.status.busy": "2021-01-26T14:55:34.227061Z",
+     "iopub.status.idle": "2021-01-26T14:55:34.230071Z",
+     "shell.execute_reply": "2021-01-26T14:55:34.229548Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -449,7 +505,14 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-01-26T14:55:34.546529Z",
+     "iopub.status.busy": "2021-01-26T14:55:34.546058Z",
+     "iopub.status.idle": "2021-01-26T14:55:35.104285Z",
+     "shell.execute_reply": "2021-01-26T14:55:35.104663Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -510,7 +573,7 @@
        "    NCO:            4.0.9"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -531,16 +594,15 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-01-26T14:55:35.109421Z",
+     "iopub.status.busy": "2021-01-26T14:55:35.107815Z",
+     "iopub.status.idle": "2021-01-26T14:55:37.424938Z",
+     "shell.execute_reply": "2021-01-26T14:55:37.425314Z"
+    }
+   },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Metalink content-type detected.\n",
-      "Downloading to /tmp/tmpvog3lvza/sdii_SRES-A2-experiment_20600101-20640101.nc.\n"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -561,7 +623,7 @@
        "Attributes:\n",
        "    units:          mm/day\n",
        "    cell_methods:   time: mean (interval: 30 minutes)\n",
-       "    xclim_history:  pr=max(0,pr) applied to raw data;\\n[2021-01-25 16:08:12] ...\n",
+       "    xclim_history:  pr=max(0,pr) applied to raw data;\\n[2021-01-26 09:55:36] ...\n",
        "    standard_name:  lwe_thickness_of_precipitation_amount\n",
        "    long_name:      Average precipitation during wet days (sdii)\n",
        "    description:    Annual simple daily intensity index (sdii) : annual avera...</pre>"
@@ -584,13 +646,13 @@
        "Attributes:\n",
        "    units:          mm/day\n",
        "    cell_methods:   time: mean (interval: 30 minutes)\n",
-       "    xclim_history:  pr=max(0,pr) applied to raw data;\\n[2021-01-25 16:08:12] ...\n",
+       "    xclim_history:  pr=max(0,pr) applied to raw data;\\n[2021-01-26 09:55:36] ...\n",
        "    standard_name:  lwe_thickness_of_precipitation_amount\n",
        "    long_name:      Average precipitation during wet days (sdii)\n",
        "    description:    Annual simple daily intensity index (sdii) : annual avera..."
       ]
      },
-     "execution_count": 10,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -618,7 +680,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/finch-usage.ipynb
+++ b/docs/source/notebooks/finch-usage.ipynb
@@ -12,7 +12,14 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-01-26T14:55:39.487885Z",
+     "iopub.status.busy": "2021-01-26T14:55:39.487358Z",
+     "iopub.status.idle": "2021-01-26T14:55:41.098977Z",
+     "shell.execute_reply": "2021-01-26T14:55:41.098379Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -39,7 +46,14 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-01-26T14:55:41.102739Z",
+     "iopub.status.busy": "2021-01-26T14:55:41.102222Z",
+     "iopub.status.idle": "2021-01-26T14:55:41.105713Z",
+     "shell.execute_reply": "2021-01-26T14:55:41.106205Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -47,7 +61,7 @@
      "text": [
       "Help on method frost_days in module birdy.client.base:\n",
       "\n",
-      "frost_days(tasmin=None, missing_options=None, check_missing='any', freq='YS', variable=None, output_formats=None) method of birdy.client.base.WPSClient instance\n",
+      "frost_days(tasmin=None, missing_options=None, check_missing='any', freq='YS', variable=None) method of birdy.client.base.WPSClient instance\n",
       "    Number of days where daily minimum temperatures are below 0.\n",
       "    \n",
       "    Parameters\n",
@@ -93,7 +107,14 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-01-26T14:55:41.110320Z",
+     "iopub.status.busy": "2021-01-26T14:55:41.108696Z",
+     "iopub.status.idle": "2021-01-26T14:55:43.621024Z",
+     "shell.execute_reply": "2021-01-26T14:55:43.621576Z"
+    }
+   },
    "outputs": [],
    "source": [
     "tasmin = \"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/flyingpigeon/cmip3/tasmin.sresa2.miub_echo_g.run1.atm.da.nc\"\n",
@@ -103,14 +124,21 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-01-26T14:55:43.625693Z",
+     "iopub.status.busy": "2021-01-26T14:55:43.625167Z",
+     "iopub.status.idle": "2021-01-26T14:55:43.627836Z",
+     "shell.execute_reply": "2021-01-26T14:55:43.628393Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Process status:  ProcessSucceeded\n",
-      "Link to process output:  https://pavics.ouranos.ca/wpsoutputs/718175a4-5f51-11eb-866c-a44cc85b43bf/frost-days_SRES-A2-experiment_20460101-20650101.nc\n"
+      "Link to process output:  https://pavics.ouranos.ca/wpsoutputs/8eff008e-5fe6-11eb-986e-3417ebcfda20/frost-days_SRES-A2-experiment_20460101-20650101.nc\n"
      ]
     }
    ],
@@ -130,17 +158,15 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Metalink content-type detected.\n",
-      "Downloading to /tmp/tmpqmtnczvu/frost-days_SRES-A2-experiment_20460101-20650101.nc.\n"
-     ]
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-01-26T14:55:43.631914Z",
+     "iopub.status.busy": "2021-01-26T14:55:43.631405Z",
+     "iopub.status.idle": "2021-01-26T14:55:43.665348Z",
+     "shell.execute_reply": "2021-01-26T14:55:43.664755Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "out = resp.get(asobj=True)"
    ]
@@ -148,7 +174,14 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-01-26T14:55:43.683518Z",
+     "iopub.status.busy": "2021-01-26T14:55:43.675882Z",
+     "iopub.status.idle": "2021-01-26T14:55:43.686660Z",
+     "shell.execute_reply": "2021-01-26T14:55:43.686082Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -217,7 +250,7 @@
        "    institute_id:             CCCS"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -243,7 +276,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix the following `make test-notebooks` error (probably related to PR https://github.com/bird-house/finch/pull/142):

```
====================================================================== FAILURES ======================================================================
___________________________________________________ docs/source/notebooks/dap_subset.ipynb::Cell 9 ___________________________________________________
Notebook cell execution failed
Cell 9: Cell outputs differ

Input:
resp = wps.sdii(pr + sub)
out = resp.get(asobj=True)
out.output_netcdf.sdii

Traceback:
Missing output fields from running code: {'stdout'}

__________________________________________________ docs/source/notebooks/finch-usage.ipynb::Cell 1 ___________________________________________________
Notebook cell execution failed
Cell 1: Cell outputs differ

Input:
help(wps.frost_days)

Traceback:
 mismatch 'stdout'

 assert reference_output == test_output failed:

  'Help on meth...ut files.\n\n' == 'Help on meth...ut files.\n\n'
    Help on method frost_days in module birdy.client.base:

  - frost_days(tasmin=None, missing_options=None, check_missing='any', freq='YS', variable=None) method of birdy.client.base.WPSClient instance
  + frost_days(tasmin=None, missing_options=None, check_missing='any', freq='YS', variable=None, output_formats=None) method of birdy.client.base.WPSClient instance
  ?                                                                                            +++++++++++++++++++++
        Number of days where daily minimum temperatures are below 0.

        Parameters
        ----------
        tasmin : ComplexData:mimetype:`application/x-netcdf`, :mimetype:`application/x-ogc-dods`
            NetCDF Files or archive (tar/zip) containing netCDF files.
        freq : {'YS', 'MS', 'QS-DEC', 'AS-JUL'}string
            Resampling frequency; Defaults to "YS" (yearly).
        check_missing : {'any', 'wmo', 'pct', 'at_least_n', 'skip', 'from_context'}string
            Method used to determine which aggregations should be considered missing.
        missing_options : ComplexData:mimetype:`application/json`
            JSON representation of dictionary of missing method parameters.
        variable : string
            Name of the variable in the NetCDF file.

        Returns
        -------
        output_netcdf : ComplexData:mimetype:`application/x-netcdf`
            The indicator values computed on the original input grid.
        output_log : ComplexData:mimetype:`text/plain`
            Collected logs during process run.
        ref : ComplexData:mimetype:`application/metalink+xml; version=4.0`
            Metalink file storing all references to output files.

__________________________________________________ docs/source/notebooks/finch-usage.ipynb::Cell 4 ___________________________________________________
Notebook cell execution failed
Cell 4: Cell outputs differ

Input:
out = resp.get(asobj=True)

Traceback:
Missing output fields from running code: {'stdout'}

================================================================== warnings summary ==================================================================
/home/lvu/.conda/envs/finch/lib/python3.8/site-packages/nbval/plugin.py:115
/home/lvu/.conda/envs/finch/lib/python3.8/site-packages/nbval/plugin.py:115
  /home/lvu/.conda/envs/finch/lib/python3.8/site-packages/nbval/plugin.py:115: PytestDeprecationWarning: direct construction of IPyNbFile has been deprecated, please use IPyNbFile.from_parent
    return IPyNbFile(path, parent)

/home/lvu/.conda/envs/finch/lib/python3.8/site-packages/nbval/plugin.py:311: 16 tests with warnings
  /home/lvu/.conda/envs/finch/lib/python3.8/site-packages/nbval/plugin.py:311: PytestDeprecationWarning: direct construction of IPyNbCell has been deprecated, please use IPyNbCell.from_parent
    yield IPyNbCell('Cell ' + str(cell_num), self, cell_num,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================================================== short test summary info ===============================================================
FAILED docs/source/notebooks/dap_subset.ipynb::Cell 9
FAILED docs/source/notebooks/finch-usage.ipynb::Cell 1
FAILED docs/source/notebooks/finch-usage.ipynb::Cell 4
===================================================== 3 failed, 13 passed, 18 warnings in 15.43s =====================================================
```
