### PR TITLE
Average over shape process

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,7 +53,7 @@ extensions = [
 # inherit without having to test which work which do not.
 if os.environ.get('READTHEDOCS') == 'True':
     autodoc_mock_imports = ["numpy", "xarray", "fiona", "rasterio", "shapely",
-                            "osgeo", "pandas", "statsmodels",
+                            "osgeo", "pandas", "geopandas", "statsmodels",
                             "affine", "rasterstats", "spotpy", "matplotlib",
                             "scipy", "unidecode", "gdal", "sentry_sdk", "dask",
                             "numba", "parse", "siphon", "sklearn", "cftime",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,14 +51,15 @@ extensions = [
 # To avoid having to install these and burst memory limit on ReadTheDocs.
 # List of all tested working mock imports from all birds so new birds can
 # inherit without having to test which work which do not.
-autodoc_mock_imports = ["numpy", "xarray", "fiona", "rasterio", "shapely",
-                        "osgeo", "geopandas", "pandas", "statsmodels",
-                        "affine", "rasterstats", "spotpy", "matplotlib",
-                        "scipy", "unidecode", "gdal", "sentry_sdk", "dask",
-                        "numba", "parse", "siphon", "sklearn", "cftime",
-                        "netCDF4", "bottleneck", "ocgis", "geotiff", "geos",
-                        "hdf4", "hdf5", "zlib", "pyproj", "proj", "cartopy",
-                        "scikit-learn", "cairo"]
+if os.environ.get('READTHEDOCS') == 'True':
+    autodoc_mock_imports = ["numpy", "xarray", "fiona", "rasterio", "shapely",
+                            "osgeo", "pandas", "statsmodels",
+                            "affine", "rasterstats", "spotpy", "matplotlib",
+                            "scipy", "unidecode", "gdal", "sentry_sdk", "dask",
+                            "numba", "parse", "siphon", "sklearn", "cftime",
+                            "netCDF4", "bottleneck", "ocgis", "geotiff", "geos",
+                            "hdf4", "hdf5", "zlib", "pyproj", "proj", "cartopy",
+                            "scikit-learn", "cairo"]
 
 # Monkeypatch constant because the following are mock imports.
 # Only works if numpy is actually installed and at the same time being mocked.

--- a/docs/source/notebooks/dap_subset.ipynb
+++ b/docs/source/notebooks/dap_subset.ipynb
@@ -112,7 +112,7 @@
        "    NCO:            4.0.9"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -141,7 +141,7 @@
        "{'lat': 1, 'lon': 2, 'time': slice(5040, 6840, None)}"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -230,7 +230,7 @@
        "    NCO:            4.0.9"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -309,7 +309,7 @@
        "    NCO:            4.0.9"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -390,7 +390,7 @@
        "    NCO:            4.0.9"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -417,7 +417,7 @@
        "{'lat': 1, 'lon': 2, 'time': slice(5040, 6840, None)}"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -533,7 +533,7 @@
        "    NCO:            4.0.9"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -583,7 +583,7 @@
        "Attributes:\n",
        "    units:          mm/day\n",
        "    cell_methods:   time: mean (interval: 30 minutes)\n",
-       "    xclim_history:  pr=max(0,pr) applied to raw data;\\n[2021-02-26 16:50:31] ...\n",
+       "    xclim_history:  pr=max(0,pr) applied to raw data;\\n[2021-02-26 17:35:50] ...\n",
        "    standard_name:  lwe_thickness_of_precipitation_amount\n",
        "    long_name:      Average precipitation during wet days (sdii)\n",
        "    description:    Annual simple daily intensity index (sdii) : annual avera...</pre>"
@@ -606,13 +606,13 @@
        "Attributes:\n",
        "    units:          mm/day\n",
        "    cell_methods:   time: mean (interval: 30 minutes)\n",
-       "    xclim_history:  pr=max(0,pr) applied to raw data;\\n[2021-02-26 16:50:31] ...\n",
+       "    xclim_history:  pr=max(0,pr) applied to raw data;\\n[2021-02-26 17:35:50] ...\n",
        "    standard_name:  lwe_thickness_of_precipitation_amount\n",
        "    long_name:      Average precipitation during wet days (sdii)\n",
        "    description:    Annual simple daily intensity index (sdii) : annual avera..."
       ]
      },
-     "execution_count": 1,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -640,7 +640,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/dap_subset.ipynb
+++ b/docs/source/notebooks/dap_subset.ipynb
@@ -17,10 +17,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-01-26T14:55:29.642346Z",
-     "iopub.status.busy": "2021-01-26T14:55:29.641850Z",
-     "iopub.status.idle": "2021-01-26T14:55:31.250468Z",
-     "shell.execute_reply": "2021-01-26T14:55:31.249874Z"
+     "iopub.execute_input": "2021-02-26T21:08:26.014164Z",
+     "iopub.status.busy": "2021-02-26T21:08:26.008901Z",
+     "iopub.status.idle": "2021-02-26T21:08:28.959013Z",
+     "shell.execute_reply": "2021-02-26T21:08:28.958498Z"
     }
    },
    "outputs": [],
@@ -46,10 +46,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-01-26T14:55:31.254934Z",
-     "iopub.status.busy": "2021-01-26T14:55:31.253249Z",
-     "iopub.status.idle": "2021-01-26T14:55:32.284849Z",
-     "shell.execute_reply": "2021-01-26T14:55:32.285321Z"
+     "iopub.execute_input": "2021-02-26T21:08:28.967321Z",
+     "iopub.status.busy": "2021-02-26T21:08:28.961739Z",
+     "iopub.status.idle": "2021-02-26T21:08:30.356802Z",
+     "shell.execute_reply": "2021-02-26T21:08:30.358600Z"
     }
    },
    "outputs": [
@@ -136,10 +136,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-01-26T14:55:32.303130Z",
-     "iopub.status.busy": "2021-01-26T14:55:32.302416Z",
-     "iopub.status.idle": "2021-01-26T14:55:32.306163Z",
-     "shell.execute_reply": "2021-01-26T14:55:32.305668Z"
+     "iopub.execute_input": "2021-02-26T21:08:30.376776Z",
+     "iopub.status.busy": "2021-02-26T21:08:30.374107Z",
+     "iopub.status.idle": "2021-02-26T21:08:30.402174Z",
+     "shell.execute_reply": "2021-02-26T21:08:30.401657Z"
     }
    },
    "outputs": [
@@ -186,10 +186,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-01-26T14:55:32.613540Z",
-     "iopub.status.busy": "2021-01-26T14:55:32.613069Z",
-     "iopub.status.idle": "2021-01-26T14:55:32.622637Z",
-     "shell.execute_reply": "2021-01-26T14:55:32.622116Z"
+     "iopub.execute_input": "2021-02-26T21:08:30.760084Z",
+     "iopub.status.busy": "2021-02-26T21:08:30.758417Z",
+     "iopub.status.idle": "2021-02-26T21:08:30.790413Z",
+     "shell.execute_reply": "2021-02-26T21:08:30.788721Z"
     }
    },
    "outputs": [
@@ -267,10 +267,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-01-26T14:55:32.989774Z",
-     "iopub.status.busy": "2021-01-26T14:55:32.989299Z",
-     "iopub.status.idle": "2021-01-26T14:55:33.330756Z",
-     "shell.execute_reply": "2021-01-26T14:55:33.331295Z"
+     "iopub.execute_input": "2021-02-26T21:08:31.145680Z",
+     "iopub.status.busy": "2021-02-26T21:08:31.143889Z",
+     "iopub.status.idle": "2021-02-26T21:08:31.581167Z",
+     "shell.execute_reply": "2021-02-26T21:08:31.582262Z"
     }
    },
    "outputs": [
@@ -354,10 +354,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-01-26T14:55:33.668934Z",
-     "iopub.status.busy": "2021-01-26T14:55:33.668392Z",
-     "iopub.status.idle": "2021-01-26T14:55:34.212332Z",
-     "shell.execute_reply": "2021-01-26T14:55:34.211787Z"
+     "iopub.execute_input": "2021-02-26T21:08:31.936580Z",
+     "iopub.status.busy": "2021-02-26T21:08:31.934671Z",
+     "iopub.status.idle": "2021-02-26T21:08:32.476270Z",
+     "shell.execute_reply": "2021-02-26T21:08:32.475432Z"
     }
    },
    "outputs": [
@@ -436,10 +436,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-01-26T14:55:34.217303Z",
-     "iopub.status.busy": "2021-01-26T14:55:34.216797Z",
-     "iopub.status.idle": "2021-01-26T14:55:34.220044Z",
-     "shell.execute_reply": "2021-01-26T14:55:34.219604Z"
+     "iopub.execute_input": "2021-02-26T21:08:32.484351Z",
+     "iopub.status.busy": "2021-02-26T21:08:32.483665Z",
+     "iopub.status.idle": "2021-02-26T21:08:32.488506Z",
+     "shell.execute_reply": "2021-02-26T21:08:32.489657Z"
     }
    },
    "outputs": [
@@ -463,10 +463,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-01-26T14:55:34.227572Z",
-     "iopub.status.busy": "2021-01-26T14:55:34.227061Z",
-     "iopub.status.idle": "2021-01-26T14:55:34.230071Z",
-     "shell.execute_reply": "2021-01-26T14:55:34.229548Z"
+     "iopub.execute_input": "2021-02-26T21:08:32.500460Z",
+     "iopub.status.busy": "2021-02-26T21:08:32.499888Z",
+     "iopub.status.idle": "2021-02-26T21:08:32.503139Z",
+     "shell.execute_reply": "2021-02-26T21:08:32.502480Z"
     }
    },
    "outputs": [
@@ -507,10 +507,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-01-26T14:55:34.546529Z",
-     "iopub.status.busy": "2021-01-26T14:55:34.546058Z",
-     "iopub.status.idle": "2021-01-26T14:55:35.104285Z",
-     "shell.execute_reply": "2021-01-26T14:55:35.104663Z"
+     "iopub.execute_input": "2021-02-26T21:08:33.088288Z",
+     "iopub.status.busy": "2021-02-26T21:08:33.086436Z",
+     "iopub.status.idle": "2021-02-26T21:08:33.845807Z",
+     "shell.execute_reply": "2021-02-26T21:08:33.846493Z"
     }
    },
    "outputs": [
@@ -596,10 +596,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-01-26T14:55:35.109421Z",
-     "iopub.status.busy": "2021-01-26T14:55:35.107815Z",
-     "iopub.status.idle": "2021-01-26T14:55:37.424938Z",
-     "shell.execute_reply": "2021-01-26T14:55:37.425314Z"
+     "iopub.execute_input": "2021-02-26T21:08:33.859157Z",
+     "iopub.status.busy": "2021-02-26T21:08:33.858602Z",
+     "iopub.status.idle": "2021-02-26T21:08:39.008377Z",
+     "shell.execute_reply": "2021-02-26T21:08:39.008798Z"
     }
    },
    "outputs": [
@@ -623,7 +623,7 @@
        "Attributes:\n",
        "    units:          mm/day\n",
        "    cell_methods:   time: mean (interval: 30 minutes)\n",
-       "    xclim_history:  pr=max(0,pr) applied to raw data;\\n[2021-01-26 09:55:36] ...\n",
+       "    xclim_history:  pr=max(0,pr) applied to raw data;\\n[2021-02-26 16:08:36] ...\n",
        "    standard_name:  lwe_thickness_of_precipitation_amount\n",
        "    long_name:      Average precipitation during wet days (sdii)\n",
        "    description:    Annual simple daily intensity index (sdii) : annual avera...</pre>"
@@ -646,7 +646,7 @@
        "Attributes:\n",
        "    units:          mm/day\n",
        "    cell_methods:   time: mean (interval: 30 minutes)\n",
-       "    xclim_history:  pr=max(0,pr) applied to raw data;\\n[2021-01-26 09:55:36] ...\n",
+       "    xclim_history:  pr=max(0,pr) applied to raw data;\\n[2021-02-26 16:08:36] ...\n",
        "    standard_name:  lwe_thickness_of_precipitation_amount\n",
        "    long_name:      Average precipitation during wet days (sdii)\n",
        "    description:    Annual simple daily intensity index (sdii) : annual avera..."
@@ -680,7 +680,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/dap_subset.ipynb
+++ b/docs/source/notebooks/dap_subset.ipynb
@@ -17,10 +17,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-26T21:08:26.014164Z",
-     "iopub.status.busy": "2021-02-26T21:08:26.008901Z",
-     "iopub.status.idle": "2021-02-26T21:08:28.959013Z",
-     "shell.execute_reply": "2021-02-26T21:08:28.958498Z"
+     "iopub.execute_input": "2021-02-26T21:50:08.261868Z",
+     "iopub.status.busy": "2021-02-26T21:50:08.259937Z",
+     "iopub.status.idle": "2021-02-26T21:50:22.289803Z",
+     "shell.execute_reply": "2021-02-26T21:50:22.289282Z"
     }
    },
    "outputs": [],
@@ -46,10 +46,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-26T21:08:28.967321Z",
-     "iopub.status.busy": "2021-02-26T21:08:28.961739Z",
-     "iopub.status.idle": "2021-02-26T21:08:30.356802Z",
-     "shell.execute_reply": "2021-02-26T21:08:30.358600Z"
+     "iopub.execute_input": "2021-02-26T21:50:23.587700Z",
+     "iopub.status.busy": "2021-02-26T21:50:22.307632Z",
+     "iopub.status.idle": "2021-02-26T21:50:24.751005Z",
+     "shell.execute_reply": "2021-02-26T21:50:24.751412Z"
     }
    },
    "outputs": [
@@ -68,18 +68,14 @@
        "    lon_bnds   (lon, bnds) float64 ...\n",
        "    time_bnds  (time, bnds) object ...\n",
        "    pr         (time, lat, lon) float32 ...\n",
-       "Attributes:\n",
+       "Attributes: (12/17)\n",
        "    comment:        Spinup: restart files from end of experiment 20C3M (corre...\n",
        "    title:          MIUB  model output prepared for IPCC Fourth Assessment SR...\n",
        "    cmor_version:   0.96\n",
        "    institution:    MIUB (University of Bonn, Bonn, Germany)\n",
        "    source:         ECHO-G(1999): atmosphere: ECHAM4 (T30L19) with partial se...\n",
        "    contact:        Stephanie Legutke (legutke@dkrz.de), Seung-Ki Min(skmin@u...\n",
-       "    references:     ECHAM4: E. Roeckner et al., 1996, The atmospheric general...\n",
-       "    experiment_id:  SRES A2 experiment\n",
-       "    realization:    1\n",
-       "    directory:      /ipcc/sresa2/atm/da/\n",
-       "    table_id:       Table A2 (17 November 2004)\n",
+       "    ...             ...\n",
        "    calendar:       360_day\n",
        "    project_id:     IPCC Fourth Assessment\n",
        "    Conventions:    CF-1.0\n",
@@ -100,18 +96,14 @@
        "    lon_bnds   (lon, bnds) float64 ...\n",
        "    time_bnds  (time, bnds) object ...\n",
        "    pr         (time, lat, lon) float32 ...\n",
-       "Attributes:\n",
+       "Attributes: (12/17)\n",
        "    comment:        Spinup: restart files from end of experiment 20C3M (corre...\n",
        "    title:          MIUB  model output prepared for IPCC Fourth Assessment SR...\n",
        "    cmor_version:   0.96\n",
        "    institution:    MIUB (University of Bonn, Bonn, Germany)\n",
        "    source:         ECHO-G(1999): atmosphere: ECHAM4 (T30L19) with partial se...\n",
        "    contact:        Stephanie Legutke (legutke@dkrz.de), Seung-Ki Min(skmin@u...\n",
-       "    references:     ECHAM4: E. Roeckner et al., 1996, The atmospheric general...\n",
-       "    experiment_id:  SRES A2 experiment\n",
-       "    realization:    1\n",
-       "    directory:      /ipcc/sresa2/atm/da/\n",
-       "    table_id:       Table A2 (17 November 2004)\n",
+       "    ...             ...\n",
        "    calendar:       360_day\n",
        "    project_id:     IPCC Fourth Assessment\n",
        "    Conventions:    CF-1.0\n",
@@ -136,10 +128,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-26T21:08:30.376776Z",
-     "iopub.status.busy": "2021-02-26T21:08:30.374107Z",
-     "iopub.status.idle": "2021-02-26T21:08:30.402174Z",
-     "shell.execute_reply": "2021-02-26T21:08:30.401657Z"
+     "iopub.execute_input": "2021-02-26T21:50:24.892124Z",
+     "iopub.status.busy": "2021-02-26T21:50:24.800801Z",
+     "iopub.status.idle": "2021-02-26T21:50:24.991399Z",
+     "shell.execute_reply": "2021-02-26T21:50:24.990904Z"
     }
    },
    "outputs": [
@@ -186,10 +178,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-26T21:08:30.760084Z",
-     "iopub.status.busy": "2021-02-26T21:08:30.758417Z",
-     "iopub.status.idle": "2021-02-26T21:08:30.790413Z",
-     "shell.execute_reply": "2021-02-26T21:08:30.788721Z"
+     "iopub.execute_input": "2021-02-26T21:50:25.573180Z",
+     "iopub.status.busy": "2021-02-26T21:50:25.571441Z",
+     "iopub.status.idle": "2021-02-26T21:50:25.595170Z",
+     "shell.execute_reply": "2021-02-26T21:50:25.592717Z"
     }
    },
    "outputs": [
@@ -201,18 +193,14 @@
        "Dimensions without coordinates: lat, lon, time\n",
        "Data variables:\n",
        "    pr       (time, lat, lon) float32 ...\n",
-       "Attributes:\n",
+       "Attributes: (12/17)\n",
        "    comment:        Spinup: restart files from end of experiment 20C3M (corre...\n",
        "    title:          MIUB  model output prepared for IPCC Fourth Assessment SR...\n",
        "    cmor_version:   0.96\n",
        "    institution:    MIUB (University of Bonn, Bonn, Germany)\n",
        "    source:         ECHO-G(1999): atmosphere: ECHAM4 (T30L19) with partial se...\n",
        "    contact:        Stephanie Legutke (legutke@dkrz.de), Seung-Ki Min(skmin@u...\n",
-       "    references:     ECHAM4: E. Roeckner et al., 1996, The atmospheric general...\n",
-       "    experiment_id:  SRES A2 experiment\n",
-       "    realization:    1\n",
-       "    directory:      /ipcc/sresa2/atm/da/\n",
-       "    table_id:       Table A2 (17 November 2004)\n",
+       "    ...             ...\n",
        "    calendar:       360_day\n",
        "    project_id:     IPCC Fourth Assessment\n",
        "    Conventions:    CF-1.0\n",
@@ -226,18 +214,14 @@
        "Dimensions without coordinates: lat, lon, time\n",
        "Data variables:\n",
        "    pr       (time, lat, lon) float32 ...\n",
-       "Attributes:\n",
+       "Attributes: (12/17)\n",
        "    comment:        Spinup: restart files from end of experiment 20C3M (corre...\n",
        "    title:          MIUB  model output prepared for IPCC Fourth Assessment SR...\n",
        "    cmor_version:   0.96\n",
        "    institution:    MIUB (University of Bonn, Bonn, Germany)\n",
        "    source:         ECHO-G(1999): atmosphere: ECHAM4 (T30L19) with partial se...\n",
        "    contact:        Stephanie Legutke (legutke@dkrz.de), Seung-Ki Min(skmin@u...\n",
-       "    references:     ECHAM4: E. Roeckner et al., 1996, The atmospheric general...\n",
-       "    experiment_id:  SRES A2 experiment\n",
-       "    realization:    1\n",
-       "    directory:      /ipcc/sresa2/atm/da/\n",
-       "    table_id:       Table A2 (17 November 2004)\n",
+       "    ...             ...\n",
        "    calendar:       360_day\n",
        "    project_id:     IPCC Fourth Assessment\n",
        "    Conventions:    CF-1.0\n",
@@ -267,10 +251,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-26T21:08:31.145680Z",
-     "iopub.status.busy": "2021-02-26T21:08:31.143889Z",
-     "iopub.status.idle": "2021-02-26T21:08:31.581167Z",
-     "shell.execute_reply": "2021-02-26T21:08:31.582262Z"
+     "iopub.execute_input": "2021-02-26T21:50:26.188241Z",
+     "iopub.status.busy": "2021-02-26T21:50:26.185189Z",
+     "iopub.status.idle": "2021-02-26T21:50:26.643284Z",
+     "shell.execute_reply": "2021-02-26T21:50:26.645635Z"
     }
    },
    "outputs": [
@@ -285,18 +269,14 @@
        "  * time     (time) object 2046-01-01 12:00:00\n",
        "Data variables:\n",
        "    pr       (time, lat, lon) float32 ...\n",
-       "Attributes:\n",
+       "Attributes: (12/17)\n",
        "    comment:        Spinup: restart files from end of experiment 20C3M (corre...\n",
        "    title:          MIUB  model output prepared for IPCC Fourth Assessment SR...\n",
        "    cmor_version:   0.96\n",
        "    institution:    MIUB (University of Bonn, Bonn, Germany)\n",
        "    source:         ECHO-G(1999): atmosphere: ECHAM4 (T30L19) with partial se...\n",
        "    contact:        Stephanie Legutke (legutke@dkrz.de), Seung-Ki Min(skmin@u...\n",
-       "    references:     ECHAM4: E. Roeckner et al., 1996, The atmospheric general...\n",
-       "    experiment_id:  SRES A2 experiment\n",
-       "    realization:    1\n",
-       "    directory:      /ipcc/sresa2/atm/da/\n",
-       "    table_id:       Table A2 (17 November 2004)\n",
+       "    ...             ...\n",
        "    calendar:       360_day\n",
        "    project_id:     IPCC Fourth Assessment\n",
        "    Conventions:    CF-1.0\n",
@@ -313,18 +293,14 @@
        "  * time     (time) object 2046-01-01 12:00:00\n",
        "Data variables:\n",
        "    pr       (time, lat, lon) float32 ...\n",
-       "Attributes:\n",
+       "Attributes: (12/17)\n",
        "    comment:        Spinup: restart files from end of experiment 20C3M (corre...\n",
        "    title:          MIUB  model output prepared for IPCC Fourth Assessment SR...\n",
        "    cmor_version:   0.96\n",
        "    institution:    MIUB (University of Bonn, Bonn, Germany)\n",
        "    source:         ECHO-G(1999): atmosphere: ECHAM4 (T30L19) with partial se...\n",
        "    contact:        Stephanie Legutke (legutke@dkrz.de), Seung-Ki Min(skmin@u...\n",
-       "    references:     ECHAM4: E. Roeckner et al., 1996, The atmospheric general...\n",
-       "    experiment_id:  SRES A2 experiment\n",
-       "    realization:    1\n",
-       "    directory:      /ipcc/sresa2/atm/da/\n",
-       "    table_id:       Table A2 (17 November 2004)\n",
+       "    ...             ...\n",
        "    calendar:       360_day\n",
        "    project_id:     IPCC Fourth Assessment\n",
        "    Conventions:    CF-1.0\n",
@@ -354,10 +330,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-26T21:08:31.936580Z",
-     "iopub.status.busy": "2021-02-26T21:08:31.934671Z",
-     "iopub.status.idle": "2021-02-26T21:08:32.476270Z",
-     "shell.execute_reply": "2021-02-26T21:08:32.475432Z"
+     "iopub.execute_input": "2021-02-26T21:50:27.028456Z",
+     "iopub.status.busy": "2021-02-26T21:50:27.026228Z",
+     "iopub.status.idle": "2021-02-26T21:50:27.576365Z",
+     "shell.execute_reply": "2021-02-26T21:50:27.576861Z"
     }
    },
    "outputs": [
@@ -373,18 +349,14 @@
        "Dimensions without coordinates: time_1\n",
        "Data variables:\n",
        "    pr       (time_1, lat, lon) float32 ...\n",
-       "Attributes:\n",
+       "Attributes: (12/17)\n",
        "    comment:        Spinup: restart files from end of experiment 20C3M (corre...\n",
        "    title:          MIUB  model output prepared for IPCC Fourth Assessment SR...\n",
        "    cmor_version:   0.96\n",
        "    institution:    MIUB (University of Bonn, Bonn, Germany)\n",
        "    source:         ECHO-G(1999): atmosphere: ECHAM4 (T30L19) with partial se...\n",
        "    contact:        Stephanie Legutke (legutke@dkrz.de), Seung-Ki Min(skmin@u...\n",
-       "    references:     ECHAM4: E. Roeckner et al., 1996, The atmospheric general...\n",
-       "    experiment_id:  SRES A2 experiment\n",
-       "    realization:    1\n",
-       "    directory:      /ipcc/sresa2/atm/da/\n",
-       "    table_id:       Table A2 (17 November 2004)\n",
+       "    ...             ...\n",
        "    calendar:       360_day\n",
        "    project_id:     IPCC Fourth Assessment\n",
        "    Conventions:    CF-1.0\n",
@@ -402,18 +374,14 @@
        "Dimensions without coordinates: time_1\n",
        "Data variables:\n",
        "    pr       (time_1, lat, lon) float32 ...\n",
-       "Attributes:\n",
+       "Attributes: (12/17)\n",
        "    comment:        Spinup: restart files from end of experiment 20C3M (corre...\n",
        "    title:          MIUB  model output prepared for IPCC Fourth Assessment SR...\n",
        "    cmor_version:   0.96\n",
        "    institution:    MIUB (University of Bonn, Bonn, Germany)\n",
        "    source:         ECHO-G(1999): atmosphere: ECHAM4 (T30L19) with partial se...\n",
        "    contact:        Stephanie Legutke (legutke@dkrz.de), Seung-Ki Min(skmin@u...\n",
-       "    references:     ECHAM4: E. Roeckner et al., 1996, The atmospheric general...\n",
-       "    experiment_id:  SRES A2 experiment\n",
-       "    realization:    1\n",
-       "    directory:      /ipcc/sresa2/atm/da/\n",
-       "    table_id:       Table A2 (17 November 2004)\n",
+       "    ...             ...\n",
        "    calendar:       360_day\n",
        "    project_id:     IPCC Fourth Assessment\n",
        "    Conventions:    CF-1.0\n",
@@ -436,10 +404,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-26T21:08:32.484351Z",
-     "iopub.status.busy": "2021-02-26T21:08:32.483665Z",
-     "iopub.status.idle": "2021-02-26T21:08:32.488506Z",
-     "shell.execute_reply": "2021-02-26T21:08:32.489657Z"
+     "iopub.execute_input": "2021-02-26T21:50:27.581333Z",
+     "iopub.status.busy": "2021-02-26T21:50:27.580907Z",
+     "iopub.status.idle": "2021-02-26T21:50:27.583237Z",
+     "shell.execute_reply": "2021-02-26T21:50:27.583650Z"
     }
    },
    "outputs": [
@@ -463,10 +431,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-26T21:08:32.500460Z",
-     "iopub.status.busy": "2021-02-26T21:08:32.499888Z",
-     "iopub.status.idle": "2021-02-26T21:08:32.503139Z",
-     "shell.execute_reply": "2021-02-26T21:08:32.502480Z"
+     "iopub.execute_input": "2021-02-26T21:50:27.589528Z",
+     "iopub.status.busy": "2021-02-26T21:50:27.589094Z",
+     "iopub.status.idle": "2021-02-26T21:50:27.591447Z",
+     "shell.execute_reply": "2021-02-26T21:50:27.591018Z"
     }
    },
    "outputs": [
@@ -507,10 +475,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-26T21:08:33.088288Z",
-     "iopub.status.busy": "2021-02-26T21:08:33.086436Z",
-     "iopub.status.idle": "2021-02-26T21:08:33.845807Z",
-     "shell.execute_reply": "2021-02-26T21:08:33.846493Z"
+     "iopub.execute_input": "2021-02-26T21:50:27.929272Z",
+     "iopub.status.busy": "2021-02-26T21:50:27.928894Z",
+     "iopub.status.idle": "2021-02-26T21:50:28.657296Z",
+     "shell.execute_reply": "2021-02-26T21:50:28.656813Z"
     }
    },
    "outputs": [
@@ -525,18 +493,14 @@
        "  * time     (time) object 2060-01-01 12:00:00 ... 2064-12-30 12:00:00\n",
        "Data variables:\n",
        "    pr       (time, lat, lon) float32 ...\n",
-       "Attributes:\n",
+       "Attributes: (12/17)\n",
        "    comment:        Spinup: restart files from end of experiment 20C3M (corre...\n",
        "    title:          MIUB  model output prepared for IPCC Fourth Assessment SR...\n",
        "    cmor_version:   0.96\n",
        "    institution:    MIUB (University of Bonn, Bonn, Germany)\n",
        "    source:         ECHO-G(1999): atmosphere: ECHAM4 (T30L19) with partial se...\n",
        "    contact:        Stephanie Legutke (legutke@dkrz.de), Seung-Ki Min(skmin@u...\n",
-       "    references:     ECHAM4: E. Roeckner et al., 1996, The atmospheric general...\n",
-       "    experiment_id:  SRES A2 experiment\n",
-       "    realization:    1\n",
-       "    directory:      /ipcc/sresa2/atm/da/\n",
-       "    table_id:       Table A2 (17 November 2004)\n",
+       "    ...             ...\n",
        "    calendar:       360_day\n",
        "    project_id:     IPCC Fourth Assessment\n",
        "    Conventions:    CF-1.0\n",
@@ -553,18 +517,14 @@
        "  * time     (time) object 2060-01-01 12:00:00 ... 2064-12-30 12:00:00\n",
        "Data variables:\n",
        "    pr       (time, lat, lon) float32 ...\n",
-       "Attributes:\n",
+       "Attributes: (12/17)\n",
        "    comment:        Spinup: restart files from end of experiment 20C3M (corre...\n",
        "    title:          MIUB  model output prepared for IPCC Fourth Assessment SR...\n",
        "    cmor_version:   0.96\n",
        "    institution:    MIUB (University of Bonn, Bonn, Germany)\n",
        "    source:         ECHO-G(1999): atmosphere: ECHAM4 (T30L19) with partial se...\n",
        "    contact:        Stephanie Legutke (legutke@dkrz.de), Seung-Ki Min(skmin@u...\n",
-       "    references:     ECHAM4: E. Roeckner et al., 1996, The atmospheric general...\n",
-       "    experiment_id:  SRES A2 experiment\n",
-       "    realization:    1\n",
-       "    directory:      /ipcc/sresa2/atm/da/\n",
-       "    table_id:       Table A2 (17 November 2004)\n",
+       "    ...             ...\n",
        "    calendar:       360_day\n",
        "    project_id:     IPCC Fourth Assessment\n",
        "    Conventions:    CF-1.0\n",
@@ -596,10 +556,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-26T21:08:33.859157Z",
-     "iopub.status.busy": "2021-02-26T21:08:33.858602Z",
-     "iopub.status.idle": "2021-02-26T21:08:39.008377Z",
-     "shell.execute_reply": "2021-02-26T21:08:39.008798Z"
+     "iopub.execute_input": "2021-02-26T21:50:28.660933Z",
+     "iopub.status.busy": "2021-02-26T21:50:28.660508Z",
+     "iopub.status.idle": "2021-02-26T21:50:34.312787Z",
+     "shell.execute_reply": "2021-02-26T21:50:34.311856Z"
     }
    },
    "outputs": [
@@ -623,7 +583,7 @@
        "Attributes:\n",
        "    units:          mm/day\n",
        "    cell_methods:   time: mean (interval: 30 minutes)\n",
-       "    xclim_history:  pr=max(0,pr) applied to raw data;\\n[2021-02-26 16:08:36] ...\n",
+       "    xclim_history:  pr=max(0,pr) applied to raw data;\\n[2021-02-26 16:50:31] ...\n",
        "    standard_name:  lwe_thickness_of_precipitation_amount\n",
        "    long_name:      Average precipitation during wet days (sdii)\n",
        "    description:    Annual simple daily intensity index (sdii) : annual avera...</pre>"
@@ -646,7 +606,7 @@
        "Attributes:\n",
        "    units:          mm/day\n",
        "    cell_methods:   time: mean (interval: 30 minutes)\n",
-       "    xclim_history:  pr=max(0,pr) applied to raw data;\\n[2021-02-26 16:08:36] ...\n",
+       "    xclim_history:  pr=max(0,pr) applied to raw data;\\n[2021-02-26 16:50:31] ...\n",
        "    standard_name:  lwe_thickness_of_precipitation_amount\n",
        "    long_name:      Average precipitation during wet days (sdii)\n",
        "    description:    Annual simple daily intensity index (sdii) : annual avera..."

--- a/docs/source/notebooks/finch-usage.ipynb
+++ b/docs/source/notebooks/finch-usage.ipynb
@@ -14,10 +14,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-26T21:08:41.555445Z",
-     "iopub.status.busy": "2021-02-26T21:08:41.548973Z",
-     "iopub.status.idle": "2021-02-26T21:08:43.566214Z",
-     "shell.execute_reply": "2021-02-26T21:08:43.565690Z"
+     "iopub.execute_input": "2021-02-26T21:50:36.795764Z",
+     "iopub.status.busy": "2021-02-26T21:50:36.793713Z",
+     "iopub.status.idle": "2021-02-26T21:50:38.796811Z",
+     "shell.execute_reply": "2021-02-26T21:50:38.797121Z"
     }
    },
    "outputs": [],
@@ -48,10 +48,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-26T21:08:43.569672Z",
-     "iopub.status.busy": "2021-02-26T21:08:43.569247Z",
-     "iopub.status.idle": "2021-02-26T21:08:43.571313Z",
-     "shell.execute_reply": "2021-02-26T21:08:43.571747Z"
+     "iopub.execute_input": "2021-02-26T21:50:38.800468Z",
+     "iopub.status.busy": "2021-02-26T21:50:38.800057Z",
+     "iopub.status.idle": "2021-02-26T21:50:38.802194Z",
+     "shell.execute_reply": "2021-02-26T21:50:38.802565Z"
     }
    },
    "outputs": [
@@ -109,10 +109,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-26T21:08:43.580754Z",
-     "iopub.status.busy": "2021-02-26T21:08:43.578092Z",
-     "iopub.status.idle": "2021-02-26T21:08:48.835687Z",
-     "shell.execute_reply": "2021-02-26T21:08:48.833920Z"
+     "iopub.execute_input": "2021-02-26T21:50:38.811290Z",
+     "iopub.status.busy": "2021-02-26T21:50:38.810863Z",
+     "iopub.status.idle": "2021-02-26T21:50:42.656454Z",
+     "shell.execute_reply": "2021-02-26T21:50:42.655925Z"
     }
    },
    "outputs": [],
@@ -126,10 +126,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-26T21:08:48.847494Z",
-     "iopub.status.busy": "2021-02-26T21:08:48.844546Z",
-     "iopub.status.idle": "2021-02-26T21:08:48.855125Z",
-     "shell.execute_reply": "2021-02-26T21:08:48.856762Z"
+     "iopub.execute_input": "2021-02-26T21:50:42.660363Z",
+     "iopub.status.busy": "2021-02-26T21:50:42.659898Z",
+     "iopub.status.idle": "2021-02-26T21:50:42.662611Z",
+     "shell.execute_reply": "2021-02-26T21:50:42.662181Z"
     }
    },
    "outputs": [
@@ -138,7 +138,7 @@
      "output_type": "stream",
      "text": [
       "Process status:  ProcessSucceeded\n",
-      "Link to process output:  https://pavics.ouranos.ca/wpsoutputs/cecb17a4-7876-11eb-af35-9c305b4af68f/frost-days_SRES-A2-experiment_20460101-20650101.nc\n"
+      "Link to process output:  https://pavics.ouranos.ca/wpsoutputs/a9fc8bfa-787c-11eb-b0b5-9c305b4af68f/frost-days_SRES-A2-experiment_20460101-20650101.nc\n"
      ]
     }
    ],
@@ -160,10 +160,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-26T21:08:48.868564Z",
-     "iopub.status.busy": "2021-02-26T21:08:48.866639Z",
-     "iopub.status.idle": "2021-02-26T21:08:48.911667Z",
-     "shell.execute_reply": "2021-02-26T21:08:48.911179Z"
+     "iopub.execute_input": "2021-02-26T21:50:42.670087Z",
+     "iopub.status.busy": "2021-02-26T21:50:42.669654Z",
+     "iopub.status.idle": "2021-02-26T21:50:42.690853Z",
+     "shell.execute_reply": "2021-02-26T21:50:42.690392Z"
     }
    },
    "outputs": [],
@@ -176,10 +176,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-26T21:08:48.930048Z",
-     "iopub.status.busy": "2021-02-26T21:08:48.929487Z",
-     "iopub.status.idle": "2021-02-26T21:08:48.933078Z",
-     "shell.execute_reply": "2021-02-26T21:08:48.932532Z"
+     "iopub.execute_input": "2021-02-26T21:50:42.708890Z",
+     "iopub.status.busy": "2021-02-26T21:50:42.708456Z",
+     "iopub.status.idle": "2021-02-26T21:50:42.711700Z",
+     "shell.execute_reply": "2021-02-26T21:50:42.711251Z"
     }
    },
    "outputs": [
@@ -195,21 +195,14 @@
        "  * lon         (lon) float64 281.2 285.0 288.8 292.5 296.2 300.0 303.8\n",
        "Data variables:\n",
        "    frost_days  (time, lat, lon) timedelta64[ns] ...\n",
-       "Attributes:\n",
+       "Attributes: (12/20)\n",
        "    comment:                  Spinup: restart files from end of experiment 20...\n",
        "    title:                    MIUB  model output prepared for IPCC Fourth Ass...\n",
        "    cmor_version:             0.96\n",
        "    institution:              Canadian Centre for Climate Services (CCCS)\n",
        "    source:                   ECHO-G(1999): atmosphere: ECHAM4 (T30L19) with ...\n",
        "    contact:                  Canadian Centre for Climate Services\n",
-       "    references:               ECHAM4: E. Roeckner et al., 1996, The atmospher...\n",
-       "    experiment_id:            SRES A2 experiment\n",
-       "    realization:              1\n",
-       "    directory:                /ipcc/sresa2/atm/da/\n",
-       "    table_id:                 Table A2 (17 November 2004)\n",
-       "    calendar:                 360_day\n",
-       "    project_id:               IPCC Fourth Assessment\n",
-       "    Conventions:              CF-1.0\n",
+       "    ...                       ...\n",
        "    id:                       pcmdi.ipcc4.miub_echo_g.sresa2.run1.atm.da\n",
        "    history:                  Mon Aug  1 11:43:58 2011: ncks -4 -L 7 -d lat,4...\n",
        "    NCO:                      4.0.9\n",
@@ -227,21 +220,14 @@
        "  * lon         (lon) float64 281.2 285.0 288.8 292.5 296.2 300.0 303.8\n",
        "Data variables:\n",
        "    frost_days  (time, lat, lon) timedelta64[ns] ...\n",
-       "Attributes:\n",
+       "Attributes: (12/20)\n",
        "    comment:                  Spinup: restart files from end of experiment 20...\n",
        "    title:                    MIUB  model output prepared for IPCC Fourth Ass...\n",
        "    cmor_version:             0.96\n",
        "    institution:              Canadian Centre for Climate Services (CCCS)\n",
        "    source:                   ECHO-G(1999): atmosphere: ECHAM4 (T30L19) with ...\n",
        "    contact:                  Canadian Centre for Climate Services\n",
-       "    references:               ECHAM4: E. Roeckner et al., 1996, The atmospher...\n",
-       "    experiment_id:            SRES A2 experiment\n",
-       "    realization:              1\n",
-       "    directory:                /ipcc/sresa2/atm/da/\n",
-       "    table_id:                 Table A2 (17 November 2004)\n",
-       "    calendar:                 360_day\n",
-       "    project_id:               IPCC Fourth Assessment\n",
-       "    Conventions:              CF-1.0\n",
+       "    ...                       ...\n",
        "    id:                       pcmdi.ipcc4.miub_echo_g.sresa2.run1.atm.da\n",
        "    history:                  Mon Aug  1 11:43:58 2011: ncks -4 -L 7 -d lat,4...\n",
        "    NCO:                      4.0.9\n",

--- a/docs/source/notebooks/finch-usage.ipynb
+++ b/docs/source/notebooks/finch-usage.ipynb
@@ -14,10 +14,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-01-26T14:55:39.487885Z",
-     "iopub.status.busy": "2021-01-26T14:55:39.487358Z",
-     "iopub.status.idle": "2021-01-26T14:55:41.098977Z",
-     "shell.execute_reply": "2021-01-26T14:55:41.098379Z"
+     "iopub.execute_input": "2021-02-26T21:08:41.555445Z",
+     "iopub.status.busy": "2021-02-26T21:08:41.548973Z",
+     "iopub.status.idle": "2021-02-26T21:08:43.566214Z",
+     "shell.execute_reply": "2021-02-26T21:08:43.565690Z"
     }
    },
    "outputs": [],
@@ -48,10 +48,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-01-26T14:55:41.102739Z",
-     "iopub.status.busy": "2021-01-26T14:55:41.102222Z",
-     "iopub.status.idle": "2021-01-26T14:55:41.105713Z",
-     "shell.execute_reply": "2021-01-26T14:55:41.106205Z"
+     "iopub.execute_input": "2021-02-26T21:08:43.569672Z",
+     "iopub.status.busy": "2021-02-26T21:08:43.569247Z",
+     "iopub.status.idle": "2021-02-26T21:08:43.571313Z",
+     "shell.execute_reply": "2021-02-26T21:08:43.571747Z"
     }
    },
    "outputs": [
@@ -61,7 +61,7 @@
      "text": [
       "Help on method frost_days in module birdy.client.base:\n",
       "\n",
-      "frost_days(tasmin=None, missing_options=None, check_missing='any', freq='YS', variable=None, output_formats=None) method of birdy.client.base.WPSClient instance\n",
+      "frost_days(tasmin=None, missing_options=None, check_missing='any', freq='YS', variable=None) method of birdy.client.base.WPSClient instance\n",
       "    Number of days where daily minimum temperatures are below 0.\n",
       "    \n",
       "    Parameters\n",
@@ -109,10 +109,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-01-26T14:55:41.110320Z",
-     "iopub.status.busy": "2021-01-26T14:55:41.108696Z",
-     "iopub.status.idle": "2021-01-26T14:55:43.621024Z",
-     "shell.execute_reply": "2021-01-26T14:55:43.621576Z"
+     "iopub.execute_input": "2021-02-26T21:08:43.580754Z",
+     "iopub.status.busy": "2021-02-26T21:08:43.578092Z",
+     "iopub.status.idle": "2021-02-26T21:08:48.835687Z",
+     "shell.execute_reply": "2021-02-26T21:08:48.833920Z"
     }
    },
    "outputs": [],
@@ -126,10 +126,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-01-26T14:55:43.625693Z",
-     "iopub.status.busy": "2021-01-26T14:55:43.625167Z",
-     "iopub.status.idle": "2021-01-26T14:55:43.627836Z",
-     "shell.execute_reply": "2021-01-26T14:55:43.628393Z"
+     "iopub.execute_input": "2021-02-26T21:08:48.847494Z",
+     "iopub.status.busy": "2021-02-26T21:08:48.844546Z",
+     "iopub.status.idle": "2021-02-26T21:08:48.855125Z",
+     "shell.execute_reply": "2021-02-26T21:08:48.856762Z"
     }
    },
    "outputs": [
@@ -138,7 +138,7 @@
      "output_type": "stream",
      "text": [
       "Process status:  ProcessSucceeded\n",
-      "Link to process output:  https://pavics.ouranos.ca/wpsoutputs/29ad410a-656d-11eb-8a55-0242ac12000c/frost-days_SRES-A2-experiment_20460101-20650101.nc\n"
+      "Link to process output:  https://pavics.ouranos.ca/wpsoutputs/cecb17a4-7876-11eb-af35-9c305b4af68f/frost-days_SRES-A2-experiment_20460101-20650101.nc\n"
      ]
     }
    ],
@@ -160,10 +160,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-01-26T14:55:43.631914Z",
-     "iopub.status.busy": "2021-01-26T14:55:43.631405Z",
-     "iopub.status.idle": "2021-01-26T14:55:43.665348Z",
-     "shell.execute_reply": "2021-01-26T14:55:43.664755Z"
+     "iopub.execute_input": "2021-02-26T21:08:48.868564Z",
+     "iopub.status.busy": "2021-02-26T21:08:48.866639Z",
+     "iopub.status.idle": "2021-02-26T21:08:48.911667Z",
+     "shell.execute_reply": "2021-02-26T21:08:48.911179Z"
     }
    },
    "outputs": [],
@@ -176,10 +176,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-01-26T14:55:43.683518Z",
-     "iopub.status.busy": "2021-01-26T14:55:43.675882Z",
-     "iopub.status.idle": "2021-01-26T14:55:43.686660Z",
-     "shell.execute_reply": "2021-01-26T14:55:43.686082Z"
+     "iopub.execute_input": "2021-02-26T21:08:48.930048Z",
+     "iopub.status.busy": "2021-02-26T21:08:48.929487Z",
+     "iopub.status.idle": "2021-02-26T21:08:48.933078Z",
+     "shell.execute_reply": "2021-02-26T21:08:48.932532Z"
     }
    },
    "outputs": [
@@ -250,7 +250,7 @@
        "    institute_id:             CCCS"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -276,7 +276,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/finch-usage.ipynb
+++ b/docs/source/notebooks/finch-usage.ipynb
@@ -61,7 +61,7 @@
      "text": [
       "Help on method frost_days in module birdy.client.base:\n",
       "\n",
-      "frost_days(tasmin=None, missing_options=None, check_missing='any', freq='YS', variable=None) method of birdy.client.base.WPSClient instance\n",
+      "frost_days(tasmin=None, missing_options=None, check_missing='any', freq='YS', variable=None, output_formats=None) method of birdy.client.base.WPSClient instance\n",
       "    Number of days where daily minimum temperatures are below 0.\n",
       "    \n",
       "    Parameters\n",
@@ -138,7 +138,7 @@
      "output_type": "stream",
      "text": [
       "Process status:  ProcessSucceeded\n",
-      "Link to process output:  https://pavics.ouranos.ca/wpsoutputs/a9fc8bfa-787c-11eb-b0b5-9c305b4af68f/frost-days_SRES-A2-experiment_20460101-20650101.nc\n"
+      "Link to process output:  https://pavics.ouranos.ca/wpsoutputs/ff0e8566-7882-11eb-becc-9c305b4af68f/frost-days_SRES-A2-experiment_20460101-20650101.nc\n"
      ]
     }
    ],
@@ -236,7 +236,7 @@
        "    institute_id:             CCCS"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -262,7 +262,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - siphon
   # remember to match xclim version in environment-docs.yml as well
   - xclim==0.23
-  - clisops>=0.5.1,<0.6.0
+  - clisops>=0.6.1
   - pywps==4.2.10
   - parse
   - pandoc  # for building docs on Travis-CI, version on Pypi too old

--- a/finch/processes/__init__.py
+++ b/finch/processes/__init__.py
@@ -20,6 +20,7 @@ from .wps_xsubset_point_dataset import (
     SubsetGridPointDatasetProcess,
 )
 from .wps_xsubset_polygon import SubsetPolygonProcess
+from .wps_xaverage_polygon import AveragePolygonProcess
 
 logger = logging.getLogger("PYWPS")
 
@@ -125,6 +126,7 @@ def get_processes(all_processes=False):
         SubsetBboxProcess(),
         SubsetGridPointProcess(),
         SubsetPolygonProcess(),
+        AveragePolygonProcess(),
     ]
 
     return processes

--- a/finch/processes/subset.py
+++ b/finch/processes/subset.py
@@ -3,10 +3,12 @@ from pathlib import Path
 from threading import Lock
 from typing import List
 
+import geopandas as gpd
 from pywps import ComplexInput, Process
 from pywps.app.exceptions import ProcessError
 import xarray as xr
-from xclim.subset import subset_bbox, subset_gridpoint, subset_shape
+from xclim.subset import subset_bbox, subset_gridpoint, subset_shape, subset_time
+from clisops.core.average import average_shape
 
 from . import wpsio
 from .utils import (
@@ -200,6 +202,73 @@ def extract_shp(path):
     return f"zip://{path.absolute()}!{fn}"
 
 
+def finch_average_shape(
+    process: Process, netcdf_inputs: List[ComplexInput], request_inputs: RequestInputs,
+) -> List[Path]:
+    """Parse wps `request_inputs` based on their name and average `netcdf_inputs`.
+
+    The expected names of the request_inputs are as followed (taken from `wpsio.py`):
+     - shape: Polygon contour to average the data over.
+     - start_date: Initial date for temporal subsetting.
+     - end_date: Final date for temporal subsetting.
+    """
+    shp = Path(request_inputs[wpsio.shape.identifier][0].file)
+    if shp.suffix == ".zip":
+        shp = extract_shp(shp)
+
+    start_date = single_input_or_none(request_inputs, wpsio.start_date.identifier)
+    end_date = single_input_or_none(request_inputs, wpsio.end_date.identifier)
+    tolerance = single_input_or_none(request_inputs, wpsio.tolerance.identifier)
+    variables = [r.data for r in request_inputs.get("variable", [])]
+
+    shape = gpd.read_file(shp)
+    if tolerance > 0:
+        shape['geometry'] = shape.simplify(tolerance)
+
+    n_files = len(netcdf_inputs)
+    count = 0
+
+    output_files = []
+
+    lock = Lock()
+
+    def _average(resource):
+        nonlocal count
+
+        # if not subsetting by time, it's not necessary to decode times
+        time_subset = start_date is not None or end_date is not None
+        dataset = try_opendap(resource, decode_times=time_subset)
+
+        with lock:
+            count += 1
+            write_log(
+                process,
+                f"Averaging file {count} of {n_files} ({resource.file})",
+                subtask_percentage=(count - 1) * 100 // n_files,
+            )
+
+        dataset = dataset[variables] if variables else dataset
+
+        if time_subset:
+            dataset = subset_time(dataset, start_date=start_date, end_date=end_date)
+        averaged = average_shape(dataset, shape)
+
+        if not all(averaged.dims.values()):
+            LOGGER.warning(f"Average is empty for dataset: {resource.url}")
+            return
+
+        p = Path(resource._file or resource._build_file_name(resource.url))
+        output_filename = Path(process.workdir) / (p.stem + "_avg" + p.suffix)
+
+        dataset_to_netcdf(averaged, output_filename)
+
+        output_files.append(output_filename)
+
+    process_threaded(_average, netcdf_inputs)
+
+    return output_files
+
+
 def finch_subset_shape(
     process: Process, netcdf_inputs: List[ComplexInput], request_inputs: RequestInputs,
 ) -> List[Path]:
@@ -267,6 +336,7 @@ def common_subset_handler(process: Process, request, response, subset_function):
         finch_subset_bbox,
         finch_subset_gridpoint,
         finch_subset_shape,
+        finch_average_shape,
     ]
 
     write_log(process, "Processing started", process_step="start")

--- a/finch/processes/wps_xaverage_polygon.py
+++ b/finch/processes/wps_xaverage_polygon.py
@@ -1,0 +1,63 @@
+import logging
+
+from pywps import ComplexInput, ComplexOutput, FORMATS
+
+from . import wpsio
+from .wps_base import FinchProcess
+from .subset import common_subset_handler, finch_average_shape
+
+LOGGER = logging.getLogger("PYWPS")
+
+
+class AveragePolygonProcess(FinchProcess):
+    """Subset a NetCDF file using a polygon contour."""
+
+    def __init__(self):
+        inputs = [
+            ComplexInput(
+                "resource",
+                "NetCDF resource",
+                abstract="NetCDF files, can be OPEnDAP urls.",
+                max_occurs=1000,
+                supported_formats=[FORMATS.NETCDF, FORMATS.DODS],
+            ),
+            wpsio.shape,
+            wpsio.tolerance,
+            wpsio.start_date,
+            wpsio.end_date,
+            wpsio.variable_any,
+        ]
+
+        outputs = [
+            ComplexOutput(
+                "output",
+                "netCDF output",
+                as_reference=True,
+                supported_formats=[FORMATS.NETCDF],
+            ),
+            wpsio.output_metalink,
+        ]
+
+        super(AveragePolygonProcess, self).__init__(
+            self._handler,
+            identifier="average_polygon",
+            title="Average over one or more polygons",
+            version="0.1",
+            abstract=(
+                "Return the average of the data within each polygons, "
+                "taking into account partial overlaps and holes, "
+                "for each input dataset as well as the time range selected."
+            ),
+            inputs=inputs,
+            outputs=outputs,
+            status_supported=True,
+            store_supported=True,
+        )
+
+        self.status_percentage_steps = {
+            "start": 5,
+            "done": 99,
+        }
+
+    def _handler(self, request, response):
+        return common_subset_handler(self, request, response, finch_average_shape)

--- a/finch/processes/wpsio.py
+++ b/finch/processes/wpsio.py
@@ -226,3 +226,16 @@ output_metalink = ComplexOutput(
     as_reference=False,
     supported_formats=[FORMATS.META4],
 )
+
+tolerance = LiteralInput(
+    "tolerance",
+    "Tolerance",
+    abstract=(
+        "The polygon tolerance in degrees."
+        "High-resolution polygons are simplified to this tolerance "
+        "in order to speed up the averaging. Put 0 to disable that simplification."
+    ),
+    data_type="float",
+    default=0.001,
+    min_occurs=0,
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cftime
 pywps==4.2.10
 xclim~=0.23.0
 xarray
-clisops>=0.5.1,<0.6.0
+clisops>=0.6.1
 geopandas
 jinja2
 click

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,3 +15,4 @@ cruft
 nbval
 nbconvert
 birdhouse-birdy
+geojson

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,8 +64,8 @@ def _create_test_dataset(
 
     obj = xr.Dataset(attrs=attrs)
     obj["time"] = ("time", pd.date_range("2000-01-01", periods=_dims["time"]))
-    obj["lon"] = ("lon", np.arange(_dims["lon"]))
-    obj["lat"] = ("lat", np.arange(_dims["lat"]))
+    obj["lon"] = ("lon", np.arange(_dims["lon"]), {'standard_name': 'longitude'})
+    obj["lat"] = ("lat", np.arange(_dims["lat"]), {'standard_name': 'latitude'})
 
     for v, dims in sorted(_vars.items()):
         data = rs.normal(size=tuple(_dims[d] for d in dims))

--- a/tests/test_wps_caps.py
+++ b/tests/test_wps_caps.py
@@ -52,5 +52,5 @@ def test_wps_caps_no_datasets(client, monkeypatch):
         "/wps:Capabilities/wps:ProcessOfferings/wps:Process/ows:Identifier"
     ).split()
 
-    subset_processes_count = 3
+    subset_processes_count = 4
     assert len(indicators) + subset_processes_count == len(names)

--- a/tests/test_wps_xaverage_polygon.py
+++ b/tests/test_wps_xaverage_polygon.py
@@ -1,0 +1,54 @@
+import geojson
+import pytest
+import xarray as xr
+from tests.utils import execute_process, shapefile_zip, wps_input_file, wps_literal_input
+
+
+def test_wps_averagepoly(client, netcdf_datasets):
+    # --- given ---
+    identifier = "average_polygon"
+    poly = {
+        "type": "Feature",
+        "id": "apolygon",
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [[[0.5, 0], [2.5, 0], [2.5, 2.5], [0.5, 2.5]]],
+        },
+    }
+    inputs = [
+        wps_input_file("resource", f"file://{netcdf_datasets['tasmin']}"),
+        wps_literal_input("shape", geojson.dumps(poly)),
+        wps_literal_input("variable", "tasmin"),
+        wps_literal_input("start_date", "2000"),
+    ]
+
+    # --- when ---
+    outputs = execute_process(client, identifier, inputs, output_names=["output"])
+
+    # --- then ---
+    ds = xr.open_dataset(outputs[0])
+    assert ds.geom.size == 1
+    assert ds.id.values == ["apolygon"]
+
+
+@pytest.mark.parametrize("tolerance", ["0", "0.1"])
+def test_wps_averagepoly_shapefile(client, netcdf_datasets, tolerance):
+    # --- given ---
+    identifier = "average_polygon"
+    poly = shapefile_zip()
+    inputs = [
+        wps_input_file("resource", f"file://{netcdf_datasets['tasmin']}"),
+        wps_input_file("shape", poly),
+        wps_literal_input("tolerance", tolerance),
+        wps_literal_input("variable", "tasmin"),
+        wps_literal_input("start_date", "2000"),
+    ]
+
+    # --- when ---
+    outputs = execute_process(client, identifier, inputs, output_names=["output"])
+
+    # --- then ---
+    ds = xr.open_dataset(outputs[0])
+
+    assert ds.geom.size == 1
+    assert ds.FID.values == [0]


### PR DESCRIPTION
## Overview

This PR fixes #98

Changes:

* Added a `AveragePolygonProcess` (with `subset.finch_average_shape` and `wpsio.tolerance`).

## Related Issue / Discussion
Since xESMF's `SpatialAverager` is now wrapped into clisops, we can make it available here!

## Additional Information
While testing this I stumbled upon an issue with high-resolution polygons. Well more a performance caveat : xESMF "exact" weight masks can take a long time to build when the polygons have too many nodes. I introduced here a `tolerance` kwarg to simplify the polygons using shapely's algos (through geopandas). Maybe I should move that cde to clisops? Moreover, having it in clisops could allow specifying it as a percent of the gridsize (instead of degrees like now).

Secundo, I kept the time subsetting code to imitate all the other subset processes. Would be easy to remove if not needed.


Tests are still missing.