### PR TITLE
Clean environment files for xclim 0.24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ install:
   - source activate finch
   # Packages for testing, generating docs and installing WPS
   - make develop
-  # TODO: Remove when xclim 0.24 is released on conda-forge.
-  - pip install xclim
 before_script:
   # Start WPS service on port 5000 on 0.0.0.0
   - make start

--- a/environment-docs.yml
+++ b/environment-docs.yml
@@ -8,4 +8,4 @@ dependencies:
 - sphinx
 - nbsphinx
 - ipython
-- xclim>=0.23
+- xclim==0.24

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - sentry-sdk
   - siphon
   # remember to match xclim version in environment-docs.yml as well
-  - xclim>=0.23
+  - xclim==0.24
   - clisops>=0.6.1
   - pywps==4.2.10
   - parse


### PR DESCRIPTION
## Overview

The last PR (#151) was missing three changes because xclim 0.24 was not out on conda-forge yesterday night. I think I forgot to mention it in the thread. Also, the manual pip install was still in the `.travis.yml`  file!
