### PR TITLE
More flexible chunking

### DIFF
--- a/finch/processes/subset.py
+++ b/finch/processes/subset.py
@@ -22,6 +22,7 @@ from .utils import (
 )
 
 LOGGER = logging.getLogger("PYWPS")
+LOGGER.disabled = False
 
 
 def finch_subset_gridpoint(
@@ -240,7 +241,7 @@ def finch_average_shape(
 
         # if not subsetting by time, it's not necessary to decode times
         time_subset = start_date is not None or end_date is not None
-        dataset = try_opendap(resource, decode_times=time_subset)
+        dataset = try_opendap(resource, decode_times=time_subset, chunk_dims=['time', 'realization'])
 
         with lock:
             count += 1

--- a/finch/processes/subset.py
+++ b/finch/processes/subset.py
@@ -22,7 +22,6 @@ from .utils import (
 )
 
 LOGGER = logging.getLogger("PYWPS")
-LOGGER.disabled = False
 
 
 def finch_subset_gridpoint(

--- a/finch/processes/utils.py
+++ b/finch/processes/utils.py
@@ -331,7 +331,10 @@ def chunk_dataset(ds, max_size=1000000, chunk_dims=None):
 
     dims = set(ds.dims).intersection(chunk_dims or ds.dims)
     if not dims:
-        LOGGER.warning(f"Provided dimension names for chunking ({chunk_dims}) were not found in dataset dims ({ds.dims}). No chunking was done.")
+        LOGGER.warning(
+            (f"Provided dimension names for chunking ({chunk_dims}) were "
+             f"not found in dataset dims ({ds.dims}). No chunking was done.")
+        )
         return chunks
 
     def chunk_size():

--- a/finch/processes/wps_ensemble_indices_bbox.py
+++ b/finch/processes/wps_ensemble_indices_bbox.py
@@ -28,7 +28,8 @@ class XclimEnsembleBboxBase(FinchProcess):
             )
 
         attrs = self.xci.json()
-        xci_inputs = convert_xclim_inputs_to_pywps(attrs["parameters"], self.xci.identifier) + wpsio.xclim_common_options
+        xci_inputs = convert_xclim_inputs_to_pywps(attrs["parameters"], self.xci.identifier)
+        xci_inputs.extend(wpsio.xclim_common_options)
         self.xci_inputs_identifiers = [i.identifier for i in xci_inputs]
 
         inputs = [

--- a/finch/processes/wps_ensemble_indices_point.py
+++ b/finch/processes/wps_ensemble_indices_point.py
@@ -28,7 +28,8 @@ class XclimEnsembleGridPointBase(FinchProcess):
             )
 
         attrs = self.xci.json()
-        xci_inputs = convert_xclim_inputs_to_pywps(attrs["parameters"], self.xci.identifier) + wpsio.xclim_common_options
+        xci_inputs = convert_xclim_inputs_to_pywps(attrs["parameters"], self.xci.identifier)
+        xci_inputs.extend(wpsio.xclim_common_options)
         self.xci_inputs_identifiers = [i.identifier for i in xci_inputs]
 
         inputs = [

--- a/finch/processes/wps_ensemble_indices_polygon.py
+++ b/finch/processes/wps_ensemble_indices_polygon.py
@@ -27,7 +27,8 @@ class XclimEnsemblePolygonBase(FinchProcess):
             )
 
         attrs = self.xci.json()
-        xci_inputs = convert_xclim_inputs_to_pywps(attrs["parameters"], self.xci.identifier) + wpsio.xclim_common_options
+        xci_inputs = convert_xclim_inputs_to_pywps(attrs["parameters"], self.xci.identifier)
+        xci_inputs.extend(wpsio.xclim_common_options)
         self.xci_inputs_identifiers = [i.identifier for i in xci_inputs]
 
         inputs = [


### PR DESCRIPTION
## Overview

This PR fixes #169

Changes:

* Added a keyword `chunk_dims` to `utils.chunk_dataset`. When given, only dimensions listed there may be chunked.
* `average_shape` passes "['time', 'realization']", so the spatial dimensions are not chunked.

## Related Issue / Discussion
Well, this is not a nice fix at all. However, the problem is that finch does not know the names of the spatial dimensions and thus can't control the chunks on them. 

I also though of:

1. Catching the error, parsing the dimension name out of it, rechunking and trying again (ugly and inefficient)
2. Modifying `clisops` so that it can rechunk on-the-fly (ugly and inefficient as well)`
3. Moving the `average_shape` code from `clisops` to `finch`, so we know the spatial dimension names and can control chunking, may be reopening the file if needed (less elegant, but not ugly).
4. Modifying `xESMF` and `clisops` to allow passing of the `allow_rechunk` dask args (allowing dask to rechunk on the fly) (ugly and inefficient, long to implement).