### PR TITLE
test-notebooks target: nbval default ignore html and javascript output

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,3 @@
+def pytest_collectstart(collector):
+    if collector.fspath and collector.fspath.ext == '.ipynb':
+        collector.skip_compare += 'text/html', 'application/javascript',


### PR DESCRIPTION
With PR https://github.com/bird-house/finch/pull/188 removing `NBVAL_IGNORE_OUTPUT` since Jenkins is configured by
default to ignore html changes (PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/73),
test-notebooks target here is broken because it does not have the same
`conftest.py` as Jenkins.

This change brings the same `conftest.py` from Jenkins here to fix
test-notebooks target.