### PR TITLE
add missing 'min_occurs=0' to inputs that define a default

### DIFF
--- a/finch/processes/wpsio.py
+++ b/finch/processes/wpsio.py
@@ -184,6 +184,7 @@ check_missing = LiteralInput(
     data_type="string",
     default=OPTIONS[CHECK_MISSING],
     allowed_values=list(MISSING_METHODS.keys()),
+    min_occurs=0,
 )
 
 
@@ -204,6 +205,7 @@ cf_compliance = LiteralInput(
     data_type="string",
     default=OPTIONS[CF_COMPLIANCE],
     allowed_values=['log', 'warn', 'raise'],
+    min_occurs=0,
 )
 
 
@@ -214,6 +216,7 @@ data_validation = LiteralInput(
     data_type="string",
     default=OPTIONS[DATA_VALIDATION],
     allowed_values=['log', 'warn', 'raise'],
+    min_occurs=0,
 )
 
 


### PR DESCRIPTION
## Overview

Found out edited fields were reporting `minOccurs=1` although they define a `defaultValue`. 
The `Execute` validator would raise that the input is missing if we explicitly omit it to employ the default value. 

Changes:

* Add missing `min_occurs=0` parameter to inputs that define a `default` value.

## Additional Information

Found while working on following issues in attempt to parse process `ensemble_grid_point_cold_spell_duration_index` generated WPS XML into Weaver OGC-API JSON definitions: 
- https://github.com/crim-ca/weaver/issues/211
- https://github.com/crim-ca/weaver/issues/297
