### PR TITLE
run load() before switching to single-threaded scheduler

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changes
 * Update to xclim 0.31
 * Added `SENTRY_ENV` configuration
 * Possibility to pass multiple "rcp" inputs for ensemble processes.
-* Writing to netcdf is done using the single-threaded dask scheduler to avoid hanging PyWPS processes.
+* Writing to netcdf is done only after calling ``load()`` to avoid locks occurring within dask calls to ``to_netcdf`` in multi-processing mode.
 
 0.7.5 (2021-09-07)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,10 @@ Changes
 
 0.7.6 (unreleased)
 ==================
+* Update to xclim 0.31
 * Added `SENTRY_ENV` configuration
 * Possibility to pass multiple "rcp" inputs for ensemble processes.
+* Writing to netcdf is done using the single-threaded dask scheduler to avoid hanging PyWPS processes.
 
 0.7.5 (2021-09-07)
 ==================

--- a/finch/processes/utils.py
+++ b/finch/processes/utils.py
@@ -657,6 +657,9 @@ def dataset_to_netcdf(
         for v in ds.data_vars:
             encoding[v] = {"zlib": True, "complevel": compression_level}
 
-    # This is necessary when running with gunicorn
+    # Perform computations
+    ds.load()
+
+    # This is necessary when running with gunicorn to avoid lock-ups
     with dask.config.set(scheduler="single-threaded"):
         ds.to_netcdf(str(output_path), format="NETCDF4", encoding=encoding)

--- a/finch/processes/utils.py
+++ b/finch/processes/utils.py
@@ -661,5 +661,4 @@ def dataset_to_netcdf(
     ds.load()
 
     # This is necessary when running with gunicorn to avoid lock-ups
-    with dask.config.set(scheduler="single-threaded"):
-        ds.to_netcdf(str(output_path), format="NETCDF4", encoding=encoding)
+    ds.to_netcdf(str(output_path), format="NETCDF4", encoding=encoding)


### PR DESCRIPTION
## Overview

This PR fixes #204 

