### PR TITLE
Revert "added SENTRY_ENV environment variable"

### DIFF
--- a/finch/wsgi.py
+++ b/finch/wsgi.py
@@ -5,10 +5,8 @@ from pywps.app.Service import Service
 
 from .processes import get_processes
 
-SENTRY_ENV = os.environ.get("SENTRY_ENV", "production")
-
 if os.environ.get("SENTRY_DSN"):
-    sentry_sdk.init(os.environ["SENTRY_DSN"], SENTRY_ENV)
+    sentry_sdk.init(os.environ["SENTRY_DSN"])
 
 
 def create_app(cfgfiles=None):


### PR DESCRIPTION
This reverts commit c461a17eb63652e8e41368ee7be3bbf1bb6a6dda.

## Overview

This PR corrects a critical issue in 0.7.6. 
According to https://develop.sentry.dev/config/, we only need to define `SENTRY_ENVIRONMENT`.

The issue in question:
```
finch         |   File "/code/finch/__init__.py", line 7, in <module>
finch         |     from .wsgi import application  # noqa: F401
finch         |   File "/code/finch/wsgi.py", line 11, in <module>
finch         |     sentry_sdk.init(os.environ["SENTRY_DSN"], SENTRY_ENV)
finch         |   File "/opt/conda/envs/finch/lib/python3.9/site-packages/sentry_sdk/hub.py", line 105, in _init
finch         |     client = Client(*args, **kwargs)  # type: ignore
finch         |   File "/opt/conda/envs/finch/lib/python3.9/site-packages/sentry_sdk/client.py", line 85, in __init__
finch         |     self.options = get_options(*args, **kwargs)  # type: Dict[str, Any]
finch         |   File "/opt/conda/envs/finch/lib/python3.9/site-packages/sentry_sdk/client.py", line 52, in _get_options
finch         |     options = dict(*args, **kwargs)
finch         | ValueError: dictionary update sequence element #0 has length 1; 2 is required
```

Changes:

* Reverted commit that adds SENTRY_ENV to sentry SDK config

