### PR TITLE
dap_subset.ipynb: add nbval-ignore-output tags to be backward-compat with older pandas

### DIFF
--- a/docs/source/notebooks/dap_subset.ipynb
+++ b/docs/source/notebooks/dap_subset.ipynb
@@ -1888,7 +1888,10 @@
      "iopub.status.busy": "2022-02-07T16:24:30.436493Z",
      "iopub.status.idle": "2022-02-07T16:24:30.446436Z",
      "shell.execute_reply": "2022-02-07T16:24:30.444737Z"
-    }
+    },
+    "tags": [
+     "nb-ignore-output"
+    ]
    },
    "outputs": [
     {
@@ -2858,7 +2861,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/dap_subset.ipynb
+++ b/docs/source/notebooks/dap_subset.ipynb
@@ -514,7 +514,7 @@
      "shell.execute_reply": "2022-02-07T16:24:28.170968Z"
     },
     "tags": [
-     "nb-ignore-output"
+     "nbval-ignore-output"
     ]
    },
    "outputs": [
@@ -530,7 +530,6 @@
     }
    ],
    "source": [
-    "#NBVAL_IGNORE_OUTPUT\n",
     "# Use the `remap_label_indexers` function to convert coordinates to *positional* indexes.\n",
     "import datetime as dt\n",
     "coords = dict(lat=45, lon=290)\n",
@@ -1890,7 +1889,7 @@
      "shell.execute_reply": "2022-02-07T16:24:30.444737Z"
     },
     "tags": [
-     "nb-ignore-output"
+     "nbval-ignore-output"
     ]
    },
    "outputs": [


### PR DESCRIPTION
There was a typo in the tag as well, it's `nbval-ignore-output` and not `nb-ignore-output` !

Related to https://github.com/bird-house/finch/pull/225#discussion_r801907479

Tested on Jenkins: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/master/1469/console

To fix this Jenkins error:

```
  _________ finch-master/docs/source/notebooks/dap_subset.ipynb::Cell 6 __________
  Notebook cell execution failed
  Cell 6: Cell outputs differ

  Input:
  index

  Traceback:
   mismatch 'text/plain'

   assert reference_output == test_output failed:

    "{'lat': arra... 6840, None)}" == "{'lat': 1, '... 6840, None)}"
    - {'lat': 1, 'lon': 2, 'time': slice(5040, 6840, None)}
    + {'lat': array(1), 'lon': array(2), 'time': slice(5040, 6840, None)}
    ?         ++++++ +         ++++++ +
```
