### PR TITLE
subset.ipynb: allow to test GeoServer on new production server

### DIFF
--- a/docs/source/notebooks/subset.ipynb
+++ b/docs/source/notebooks/subset.ipynb
@@ -196,7 +196,7 @@
     "from pathlib import Path\n",
     "\n",
     "# Connect to GeoServer WFS service.\n",
-    "wfs_url = 'https://boreas.ouranos.ca/geoserver/wfs'\n",
+    "wfs_url = 'https://pavics.ouranos.ca/geoserver/wfs'  # TEST_USE_PROD_DATA\n",
     "wfs = WebFeatureService(wfs_url, version='1.1.0')"
    ]
   },
@@ -1234,9 +1234,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "96K\t/tmp/mtl_raw.geojson\r\n",
-      "16M\t/tmp/prov_raw.geojson\r\n",
-      "800K\t/tmp/prov_simp.geojson\r\n"
+      "96K\t/tmp/mtl_raw.geojson\n",
+      "16M\t/tmp/prov_raw.geojson\n",
+      "800K\t/tmp/prov_simp.geojson\n"
      ]
     }
    ],
@@ -1729,7 +1729,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Switch from 'boreas.ouranos.ca' to 'pavics.ouranos.ca' will allow us to
conditionally regex replace 'pavics.ouranos.ca' to the server under test
so we can actually test the Geoserver on that new server.

Everywhere under this pavics-sdi repo, we use 'pavics.ouranos.ca'. This
is the only locations that hardcode 'boreas.ouranos.ca' because
geoserver data are not replicated to standard test servers so hardcoding
it this way will use the data from the production server.

This patch achieve the same "data from prod" but also allow override if
We need to actually test the future production server.

Related to https://github.com/Ouranosinc/pavics-sdi/issues/183