### PR TITLE
docker: fix mamba libarchive.so.13 not found error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
     build-essential git \
     && rm -rf /var/lib/apt/lists/* \
     && conda update conda -n base \
-    && conda install mamba -n base -c defaults -c conda-forge
+    && conda install mamba -n base -c conda-forge -c defaults
 
 WORKDIR /code
 


### PR DESCRIPTION
Apparently the `libarchive` from the `defaults` channel is broken so we
reversed the mamba install channel priority so `conda-forge` channel has
higher priority than `defaults` so `libarchive` comes from `conda-forge`
instead of `defaults`.

The side-effect is the conda flavor (the whole `base` env) is also from
`conda-forge`.  The upcoming Jupyter env has the same problem with the
same fix and all subsequent installs works fine so this side-effect
seems acceptable.

To fix this error during docker build:
https://hub.docker.com/repository/registry-1.docker.io/birdhouse/finch/builds/d18843f1-8d55-4b5b-922f-975bbba9c8f1
```
RUN conda config --add channels conda-forge && mamba env create -n finch -f environment.yml && mamba install -c conda-forge -n finch gunicorn psycopg2 && rm -rf /opt/conda/pkgs/*
  Traceback (most recent call last):
  File "/opt/conda/bin/mamba", line 7, in <module>
  from mamba.mamba import main
  File "/opt/conda/lib/python3.9/site-packages/mamba/mamba.py", line 49, in <module>
  import libmambapy as api
  File "/opt/conda/lib/python3.9/site-packages/libmambapy/__init__.py", line 7, in <module>
  raise e
  File "/opt/conda/lib/python3.9/site-packages/libmambapy/__init__.py", line 4, in <module>
  from libmambapy.bindings import * # noqa: F401,F403
  ImportError: libarchive.so.13: cannot open shared object file: No such file or directory
```

@aulemahal Once this PR is merged, you'll need to tag and release another Finch since the `v0.9.0` was never out on DockerHub due to this error.