### PR TITLE
CHANGES: add 0.9.2 release info

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 *******
 
+0.9.2 (2022-07-19)
+==================
+* Fix Finch unable to startup in the Docker image.
+
 0.9.1 (2022-07-07)
 ==================
 * Avoid using a broken version of ``libarchive`` in the Docker image.


### PR DESCRIPTION
Missed in PR https://github.com/bird-house/finch/pull/249 that effectively performed the release of 0.9.2.
