### PR TITLE
Update to xclim 0.38

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Changes
     - ``finch.processes.xclim`` was removed, there is no static module of processes.
     - Input "rcp" has been renamed to "scenario".
     - Input "dataset_name" has been fixed and renamed to "dataset".
+* Update to xclim 0.38.0.
 
 0.9.2 (2022-07-19)
 ==================

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,10 @@
 # absolute, like shown here.
 #
 import os
+from pathlib import Path
 import sys
+from urllib.request import urlopen
+from xclim import __version__ as xcver
 
 # Add finch to sys.path to avoid having to full
 # install finch for autodoc.
@@ -46,6 +49,7 @@ extensions = [
     "sphinx.ext.imgconverter",
     "nbsphinx",
     "IPython.sphinxext.ipython_console_highlighting",
+    "sphinxcontrib.bibtex"
 ]
 
 # To avoid having to install these and burst memory limit on ReadTheDocs.
@@ -78,6 +82,13 @@ if os.environ.get('READTHEDOCS') == 'True':
         "zlib",
     ]
 
+# Bibliography stuff, for correct xclim docstring formatting
+# We need to download the reference file from xclim for the correct version.
+r = urlopen(f"https://github.com/Ouranosinc/xclim/raw/v{xcver}/docs/references.bib")
+with (Path(__file__).parent / 'references.bib').open('wb') as f:
+    f.write(r.read())
+bibtex_bibfiles = ["references.bib"]
+bibtex_reference_style = "author_year"
 
 # Monkeypatch constant because the following are mock imports.
 # Only works if numpy is actually installed and at the same time being mocked.
@@ -101,7 +112,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Finch"
-copyright = "2018-2020, David Huard"
+copyright = "2018-2022, David Huard"
 author = "David Huard"
 
 # The version info for the project you're documenting, acts as replacement

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,11 +18,13 @@
 # relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
 #
+from datetime import datetime
 import os
 from pathlib import Path
 import sys
 from urllib.request import urlopen
 from xclim import __version__ as xcver
+import warnings
 
 # Add finch to sys.path to avoid having to full
 # install finch for autodoc.
@@ -84,11 +86,19 @@ if os.environ.get('READTHEDOCS') == 'True':
 
 # Bibliography stuff, for correct xclim docstring formatting
 # We need to download the reference file from xclim for the correct version.
-r = urlopen(f"https://github.com/Ouranosinc/xclim/raw/v{xcver}/docs/references.bib")
-with (Path(__file__).parent / 'references.bib').open('wb') as f:
-    f.write(r.read())
-bibtex_bibfiles = ["references.bib"]
-bibtex_reference_style = "author_year"
+bibfile = Path(__file__).parent / 'references.bib'
+if not bibfile.is_file():
+    try:
+        r = urlopen(f"https://github.com/Ouranosinc/xclim/raw/v{xcver}/docs/references.bib")
+    except Exception as err:
+        warnings.warn(f'Unable to download xclim references file, docstrings will be incomplete. (Got {err})')
+    else:
+        with bibfile.open('wb') as f:
+            f.write(r.read())
+
+if bibfile.is_file():
+    bibtex_bibfiles = ["references.bib"]
+    bibtex_reference_style = "author_year"
 
 # Monkeypatch constant because the following are mock imports.
 # Only works if numpy is actually installed and at the same time being mocked.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -122,7 +122,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Finch"
-copyright = f"2018-{date.today().year()}, David Huard"
+copyright = f"2018-{datetime.today().year}, David Huard"
 author = "David Huard"
 
 # The version info for the project you're documenting, acts as replacement

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -25,3 +25,16 @@ This page documents the processes available with the default configuration of fi
     :members:
     :imported-members:
     :undoc-members:
+
+
+xclim references
+----------------
+
+.. bibliography::
+
+McArthur Forest Fire Danger Indices methods
+*******************************************
+
+.. bibliography::
+   :labelprefix: FFDI-
+   :keyprefix: ffdi-

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -32,6 +32,7 @@ xclim references
 
 .. bibliography::
 
+.. There are other categories, but only those with references appearing in the indicator's abstract, title, parameters or returns are needed here. Those in notes don't make it to the process docstring.
 McArthur Forest Fire Danger Indices methods
 *******************************************
 

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - sentry-sdk
   - siphon
   - bottleneck
-  # remember to match xclim version in environment-docs.yml as well
+  # remember to match xclim version in requirements_docs.txt as well
   - xclim =0.38.*
   - clisops >=0.9.3
   - pywps >=4.5.1

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - siphon
   - bottleneck
   # remember to match xclim version in environment-docs.yml as well
-  - xclim =0.37.*
+  - xclim =0.38.*
   - clisops >=0.9.3
   - pywps >=4.5.1
   - parse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cftime
 pywps>=4.5.1
-xclim==0.37
+xclim==0.38
 xarray>=0.18.2
 pandas
 xesmf>=0.6.2

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -6,3 +6,4 @@ xclim==0.38
 matplotlib
 birdhouse-birdy>=0.8.1
 unidecode
+sphinxcontrib-bibtex

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -2,7 +2,7 @@ pywps >= 4.5.1
 sphinx >= 4.0
 nbsphinx
 ipython
-xclim==0.37
+xclim==0.38
 matplotlib
 birdhouse-birdy>=0.8.1
 unidecode


### PR DESCRIPTION
This branch is based on extend-dataset.

## Overview

This PR updates finch to use xclim 0.38.

Changes:

No changes were needed in the processes : all changes in finch come from changes in xclim.

For the documentation, the recent addition of a single reference bibfile in xclim made some acrobatics necessary. To correctly render the docstrings we parse from xclim, meaning having correct references, we need to have this reference file. The doc's conf downloads it each time it is run, using the installed xclim version to construct its github url.