### PR TITLE
Fix dockerfile

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Changes
     - ``finch.processes.xclim`` was removed, there is no static module of processes.
     - Input "rcp" has been renamed to "scenario".
     - Input "dataset_name" has been fixed and renamed to "dataset".
-* ``finch.wsgi.application`` had been removed.
+* ``finch.wsgi.application`` had been removed. The Dockerfile's ``gunicorn`` now calls the ``create_app`` function directly.
 * Update to xclim 0.38.0.
 
 0.9.2 (2022-07-19)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,6 @@ Changes
     - ``finch.processes.xclim`` was removed, there is no static module of processes.
     - Input "rcp" has been renamed to "scenario".
     - Input "dataset_name" has been fixed and renamed to "dataset".
-* ``finch.wsgi.application`` had been removed. The Dockerfile's ``gunicorn`` now calls the ``create_app`` function directly.
 * Update to xclim 0.38.0.
 
 0.9.2 (2022-07-19)

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ ENV PATH /opt/conda/envs/finch/bin:$PATH
 
 EXPOSE 5000
 
-CMD ["gunicorn", "--bind=0.0.0.0:5000", "-t 60", "finch.wsgi:application"]
+CMD ["gunicorn", "--bind=0.0.0.0:5000", "-t 60", "finch.wsgi:create_app()"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ ENV PATH /opt/conda/envs/finch/bin:$PATH
 
 EXPOSE 5000
 
-CMD ["gunicorn", "--bind=0.0.0.0:5000", "-t 60", "finch.wsgi:create_app()"]
+CMD ["gunicorn", "--bind=0.0.0.0:5000", "-t 60", "finch.wsgi:application"]

--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,7 @@ dependencies:
   - bottleneck
   # remember to match xclim version in requirements_docs.txt as well
   - xclim =0.38.*
+  - pint < 0.20  # xclim < 0.39 is broken by pint >= 0.20
   - clisops >=0.9.3
   - pywps >=4.5.1
   - parse

--- a/finch/wsgi.py
+++ b/finch/wsgi.py
@@ -24,3 +24,6 @@ def create_app(cfgfiles=None):
     service.processes = {p.identifier: p for p in get_processes()}
 
     return service
+
+
+application = create_app()


### PR DESCRIPTION
## Overview

This PR fixes an issue raised within #258.

Changes:

The gunicorn server in the Dockerfile now calls the  `create_app` function instead of using the removed `application` object. It makes more sense to me that application are created on demand, and not on import.