### PR TITLE
Fixed iter_local to avoid files duplication in subset operations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 *******
 
+TBD (unreleased)
+===================
+* Fixed iter_local when depth > 0 to avoid all files to be considered twice
+
 0.10.0 (2022-11-04)
 ===================
 * Generalize ensemble datasets configuration.

--- a/finch/processes/ensemble_utils.py
+++ b/finch/processes/ensemble_utils.py
@@ -132,7 +132,7 @@ def iter_local(root: Path, depth: int = -1, pattern: str = '*.nc'):
     if not root.is_absolute():
         root = (Path(__file__).parent.parent / root).resolve()
 
-    for file in root.rglob(pattern):
+    for file in root.glob(pattern):
         yield file.name, file
 
     if depth != 0:


### PR DESCRIPTION
## Overview

This PR fixes files duplication on subset operations

Changes:

* Fixed iter_local when depth > 0 to avoid all files to be considered twice
