### PR TITLE
Add workflow cancellation action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,10 @@ jobs:
     name: Code linting
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
## Overview

Changes:

* Added an action for cancelling a previous CI workflow if/when two commits are pushed in rapid succession
