### PR TITLE
Pin pandas and xarray to prevent upcoming breaking changes

### DIFF
--- a/.github/workflows/bump-version-tag.yml
+++ b/.github/workflows/bump-version-tag.yml
@@ -39,8 +39,8 @@ jobs:
           echo "current_version=${CURRENT_VERSION}"
       - name: Bump Version
         run: |
-          pip install bump2version
-          echo "running `bump2version ${{ github.event.inputs.bumpversion }}`"
+          pip install bump-my-version
+          echo "running `bump-my-version bump ${{ github.event.inputs.bumpversion }}`"
           NEW_VERSION="$(grep -E '__version__' finch/__version__.py | cut -d ' ' -f3)"
           echo "new_version=${NEW_VERSION}"
       - name: Tag Release

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 *******
 
+0.11.4 (2023-12-05)
+===================
+* Fixed a bug that occurred when fixing a broken cftime-index with newer `cftime` versions.
+* Placed pins on xarray and pandas to prevent future errors from changes to frequency codes.
+
 0.11.3 (2023-08-23)
 ===================
 * Updated ReadTheDocs to use the new mambaforge version (`2022.9`).

--- a/environment-docs.yml
+++ b/environment-docs.yml
@@ -7,8 +7,10 @@ dependencies:
   - ipython
   - matplotlib-base
   - nbsphinx
+  - pandas >=1.5.3,<2.2.0
   - pywps >=4.5.1
   - sphinx >=4.0
   - sphinxcontrib-bibtex
   - unidecode
+  - xarray >=2023.01.0,<2023.11.0
   - xclim =0.43 # remember to match xclim version in requirements_docs.txt as well

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - h5netcdf
   - netcdf4
   - numpy
-  - pandas
+  - pandas >=1.5.3,<2.2.0
   - parse
   - psutil
   - python-slugify
@@ -24,6 +24,6 @@ dependencies:
   - sentry-sdk
   - siphon
   - unidecode
-  - xarray >=2023.01.0
+  - xarray >=2023.01.0,<2023.11.0
   - xclim =0.43  # remember to match xclim version in requirements_docs.txt as well
   - xesmf >=0.8.2

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - python >=3.8,<3.12
   - pip
   - bottleneck
-  - cftime <=1.6.2
+  - cftime
   - cf_xarray
   - click
   - clisops >=0.9.3

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,8 @@ dependencies:
   - python >=3.8,<3.12
   - pip
   - bottleneck
+  - cftime <=1.6.2
+  - cf_xarray
   - click
   - clisops >=0.9.3
   - dask

--- a/finch/processes/utils.py
+++ b/finch/processes/utils.py
@@ -775,12 +775,11 @@ def fix_broken_time_index(ds: xr.Dataset):
     time_dim = ds.time.values
     times_are_encoded = "units" in ds.time.attrs
 
-    if ds.time.dt.calendar != "noleap":
-        return
-
     if times_are_encoded:
         wrong_id = np.argwhere(np.isclose(time_dim, 0))
     else:
+        if ds.time.dt.calendar != "noleap":
+            return
         wrong_id = np.argwhere(
             time_dim == cftime.DatetimeNoLeap(year=1850, month=1, day=1, hour=0)
         )

--- a/finch/processes/utils.py
+++ b/finch/processes/utils.py
@@ -775,6 +775,9 @@ def fix_broken_time_index(ds: xr.Dataset):
     time_dim = ds.time.values
     times_are_encoded = "units" in ds.time.attrs
 
+    if ds.time.dt.calendar != "noleap":
+        return
+
     if times_are_encoded:
         wrong_id = np.argwhere(np.isclose(time_dim, 0))
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ dask[complete]
 geopandas!=0.13.1
 netcdf4
 numpy
-pandas
+pandas>=1.5.3,<2.2.0
 parse
 psutil
 python-slugify
@@ -17,7 +17,7 @@ scipy
 sentry-sdk
 siphon
 unidecode
-xarray>=0.18.2
+xarray>=2023.01.0,<2023.11.0
 xclim==0.43
 xesmf>=0.6.2
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 bottleneck
-cftime
+cftime<=1.6.2
+cf-xarray
 click
 clisops>=0.9.3
 dask[complete]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bottleneck
-cftime<=1.6.2
+cftime
 cf-xarray
 click
 clisops>=0.9.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,7 +8,7 @@ nbsphinx
 nbval>=0.9.6
 nbconvert
 sphinx>=1.8.5
-bump2version
+bump-my-version
 twine
 cruft
 jupyter_client

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,4 +1,6 @@
 birdhouse-birdy>=0.8.1
+cftime<=1.6.2
+cf-xarray
 ipython
 matplotlib
 nbsphinx
@@ -7,7 +9,7 @@ pywps>=4.5.1
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
 sphinx>=4.0
 sphinxcontrib-bibtex
-unidecode
-xclim==0.43
-werkzeug>=3.0.1 # not directly required, pinned by Snyk to avoid a vulnerability
 tornado>=6.3.3 # not directly required, pinned by Snyk to avoid a vulnerability
+unidecode
+werkzeug>=3.0.1 # not directly required, pinned by Snyk to avoid a vulnerability
+xclim==0.43

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,5 +1,5 @@
 birdhouse-birdy>=0.8.1
-cftime<=1.6.2
+cftime
 cf-xarray
 ipython
 matplotlib

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -4,6 +4,7 @@ cf-xarray
 ipython
 matplotlib
 nbsphinx
+pandas>=1.5.3,<2.2.0
 pillow>=10.0.1 # not directly required, pinned by Snyk to avoid a vulnerability
 pywps>=4.5.1
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
@@ -12,4 +13,5 @@ sphinxcontrib-bibtex
 tornado>=6.3.3 # not directly required, pinned by Snyk to avoid a vulnerability
 unidecode
 werkzeug>=3.0.1 # not directly required, pinned by Snyk to avoid a vulnerability
+xarray>=2023.01.0,<2023.11.0
 xclim==0.43


### PR DESCRIPTION
## Overview

Changes:

* Added pins to xarray and pandas to prevent issues with breaking changes.
* Fixed an error with a cftime index fixing function.
* Switched `bump2version` for `bump-my-version`

## Related Issue / Discussion

https://github.com/Ouranosinc/xclim/issues/1534
https://github.com/pydata/xarray/issues/8394

## Additional Information