### PR TITLE
Prepare v0.11.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changes
 *******
 
-0.11.4 (2023-12-05)
+0.11.4 (2023-12-20)
 ===================
 * Fixed a bug that occurred when fixing a broken cftime-index with newer `cftime` versions.
 * Placed pins on xarray and pandas to prevent future errors from changes to frequency codes.


### PR DESCRIPTION
## Overview

Changes:

* Updated the release date

## Related Issue / Discussion

This will be the last point release before I modernize the package (`pyproject.toml`) to place it on PyPI. 