### PR TITLE
Replace unidecode with anyascii

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 *******
 
+0.12.1 (unreleased)
+===================
+* Replaced `unidecode` with `anyascii` due to a licensing issue.
+
 0.12.0 (2024-03-25)
 ===================
 * Renamed the installed package from `finch` to `birdhouse-finch`.
@@ -45,6 +49,7 @@ Changes
 
 0.11.1 (2023-06-19)
 ===================
+
 * Update to xclim 0.43.0.
 * Added xclim yml module support:
     - Added humidex days above calculation via yml module.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,7 +49,6 @@ Changes
 
 0.11.1 (2023-06-19)
 ===================
-
 * Update to xclim 0.43.0.
 * Added xclim yml module support:
     - Added humidex days above calculation via yml module.

--- a/environment-docs.yml
+++ b/environment-docs.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python >=3.8,<3.12
+  - anyascii
   - birdy >=0.8.1
   - ipython
   - matplotlib-base
@@ -11,6 +12,5 @@ dependencies:
   - pywps >=4.5.1
   - sphinx >=4.0
   - sphinxcontrib-bibtex
-  - unidecode
   - xarray >=2023.01.0,<2023.11.0
   - xclim =0.43 # remember to match xclim version in requirements_docs.txt as well

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - scipy
   - sentry-sdk
   - siphon
-  - unidecode
+  - anyascii
   - xarray >=2023.01.0,<2023.11.0
   - xclim =0.43  # remember to match xclim version in requirements_docs.txt as well
   - xesmf >=0.8.2

--- a/finch/processes/wps_ensemble_indices_bbox.py
+++ b/finch/processes/wps_ensemble_indices_bbox.py
@@ -1,7 +1,7 @@
 # noqa: D100
 import logging
 
-from unidecode import unidecode
+from anyascii import anyascii
 
 from finch.processes.subset import finch_subset_bbox
 
@@ -62,8 +62,8 @@ class XclimEnsembleBboxBase(FinchProcess):
             self._handler,
             identifier=identifier,
             version="0.1",
-            title=unidecode(self.xci.title),
-            abstract=unidecode(self.xci.abstract),
+            title=anyascii(self.xci.title),
+            abstract=anyascii(self.xci.abstract),
             inputs=inputs,
             outputs=outputs,
             status_supported=True,

--- a/finch/processes/wps_ensemble_indices_point.py
+++ b/finch/processes/wps_ensemble_indices_point.py
@@ -1,7 +1,7 @@
 # noqa: D100
 import logging
 
-from unidecode import unidecode
+from anyascii import anyascii
 
 from finch.processes.subset import finch_subset_gridpoint
 
@@ -60,8 +60,8 @@ class XclimEnsembleGridPointBase(FinchProcess):
             self._handler,
             identifier=identifier,
             version="0.1",
-            title=unidecode(self.xci.title),
-            abstract=unidecode(self.xci.abstract),
+            title=anyascii(self.xci.title),
+            abstract=anyascii(self.xci.abstract),
             inputs=inputs,
             outputs=outputs,
             status_supported=True,

--- a/finch/processes/wps_ensemble_indices_polygon.py
+++ b/finch/processes/wps_ensemble_indices_polygon.py
@@ -1,7 +1,7 @@
 # noqa: D100
 import logging
 
-from unidecode import unidecode
+from anyascii import anyascii
 
 from . import wpsio
 from .ensemble_utils import ensemble_common_handler
@@ -58,8 +58,8 @@ class XclimEnsemblePolygonBase(FinchProcess):
             self._handler,
             identifier=identifier,
             version="0.1",
-            title=unidecode(self.xci.title),
-            abstract=unidecode(self.xci.abstract),
+            title=anyascii(self.xci.title),
+            abstract=anyascii(self.xci.abstract),
             inputs=inputs,
             outputs=outputs,
             status_supported=True,

--- a/finch/processes/wps_xclim_indices.py
+++ b/finch/processes/wps_xclim_indices.py
@@ -8,7 +8,7 @@ import pandas as pd
 import xarray as xr
 from pandas.api.types import is_numeric_dtype
 from pywps.app.exceptions import ProcessError
-from unidecode import unidecode
+from anyascii import anyascii
 
 from . import wpsio
 from .utils import (
@@ -62,8 +62,8 @@ class XclimIndicatorBase(FinchProcess):
             self._handler,
             identifier=self.xci.identifier,
             version="0.1",
-            title=unidecode(self.xci.title),
-            abstract=unidecode(self.xci.abstract),
+            title=anyascii(self.xci.title),
+            abstract=anyascii(self.xci.abstract),
             inputs=inputs,
             outputs=outputs,
             status_supported=True,

--- a/finch/processes/wps_xclim_indices.py
+++ b/finch/processes/wps_xclim_indices.py
@@ -6,9 +6,9 @@ from typing import List, Optional
 
 import pandas as pd
 import xarray as xr
+from anyascii import anyascii
 from pandas.api.types import is_numeric_dtype
 from pywps.app.exceptions import ProcessError
-from anyascii import anyascii
 
 from . import wpsio
 from .utils import (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+anyascii
 bottleneck
 cftime
 cf-xarray
@@ -17,7 +18,6 @@ requests
 scipy
 sentry-sdk
 siphon
-unidecode
 xarray>=2023.01.0,<2023.11.0
 xclim==0.43
 xesmf>=0.6.2

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,4 @@
+anyascii
 birdhouse-birdy>=0.8.1
 cftime
 cf-xarray
@@ -11,7 +12,6 @@ setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerabil
 sphinx>=4.0
 sphinxcontrib-bibtex
 tornado>=6.3.3 # not directly required, pinned by Snyk to avoid a vulnerability
-unidecode
 werkzeug>=3.0.1 # not directly required, pinned by Snyk to avoid a vulnerability
 xarray>=2023.01.0,<2023.11.0
 xclim==0.43


### PR DESCRIPTION
## Overview

Changes:

* Replaced `unidecode` with `anyascii` due to licensing issues.

## Additional Information

`unidecode` is GPL licensed. It shouldn't be a core dependency.