### PR TITLE
Prepare v0.13.0

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -22,7 +22,7 @@
       "project_repo_name": "finch",
       "project_readthedocs_name": "finch",
       "project_short_description": "A Web Processing Service for Climate Indicators.",
-      "version": "0.12.1",
+      "version": "0.13.0-dev.0",
       "open_source_license": "Apache Software License 2.0",
       "http_port": "5000",
       "use_pytest": "y",

--- a/.cruft.json
+++ b/.cruft.json
@@ -22,7 +22,7 @@
       "project_repo_name": "finch",
       "project_readthedocs_name": "finch",
       "project_short_description": "A Web Processing Service for Climate Indicators.",
-      "version": "0.13.0-dev.0",
+      "version": "0.13.0",
       "open_source_license": "Apache Software License 2.0",
       "http_port": "5000",
       "use_pytest": "y",

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -20,12 +20,11 @@ on:
       - docs/*/*.rst
       - docs/Makefile
       - docs/_static/*
-      - environment.yml
+      - environment-dev.yml
       - environment-docs.yml
-      - finch/__version__.py
-      - requirements*.txt
-      - setup.cfg
-      - setup.py
+      - environment.yml
+      - pyproject.toml
+      - src/finch/__version__.py
 
 permissions:
   contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM condaforge/mambaforge
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PIP_ROOT_USER_ACTION=ignore
 LABEL org.opencontainers.image.authors="https://github.com/bird-house/finch"
-LABEL Description="Finch WPS" Vendor="Birdhouse" Version="0.12.1"
+LABEL Description="Finch WPS" Vendor="Birdhouse" Version="0.13.0-dev.0"
 
 # Set the working directory to /code
 WORKDIR /code

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM condaforge/mambaforge
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PIP_ROOT_USER_ACTION=ignore
 LABEL org.opencontainers.image.authors="https://github.com/bird-house/finch"
-LABEL Description="Finch WPS" Vendor="Birdhouse" Version="0.13.0-dev.0"
+LABEL Description="Finch WPS" Vendor="Birdhouse" Version="0.13.0"
 
 # Set the working directory to /code
 WORKDIR /code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ target-version = [
 ]
 
 [tool.bumpversion]
-current_version = "0.12.1"
+current_version = "0.13.0-dev.0"
 commit = true
 commit_args = "--no-verify"
 tag = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ target-version = [
 ]
 
 [tool.bumpversion]
-current_version = "0.13.0-dev.0"
+current_version = "0.13.0"
 commit = true
 commit_args = "--no-verify"
 tag = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ search = "__version__ = \"{current_version}\""
 replace = "__version__ = \"{new_version}\""
 
 [[tool.bumpversion.files]]
-filenam = "Dockerfile"
+filename = "Dockerfile"
 search = "Version=\"{current_version}\""
 replace = "Version=\"{new_version}\""
 

--- a/src/finch/__version__.py
+++ b/src/finch/__version__.py
@@ -6,4 +6,4 @@
 
 __author__ = """David Huard"""
 __email__ = "huard.david@ouranos.ca"
-__version__ = "0.12.1"
+__version__ = "0.13.0-dev.0"

--- a/src/finch/__version__.py
+++ b/src/finch/__version__.py
@@ -6,4 +6,4 @@
 
 __author__ = """David Huard"""
 __email__ = "huard.david@ouranos.ca"
-__version__ = "0.13.0-dev.0"
+__version__ = "0.13.0"


### PR DESCRIPTION
## Overview

Changes:

* Fixed a small typo in the bumpversion configuration
* Set the latest version to v0.13.0

## Related Issue / Discussion

I will be adding Trusted Publishing to the TestPyPI and PyPI configurations before the release goes live.