### PR TITLE
Prepare release v0.13.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-v0.13.0 (unreleased)
+v0.13.0 (2025-01-20)
 --------------------
 
 * Added support for Birdhouse Helper Bot (for bumping versions).


### PR DESCRIPTION
## Overview

Changes:

* Added the release date, set to next Monday (2025-01-20).

## Related Issue / Discussion

I deserve the frustration of today for attempting to break the cardinal rule:
https://www.shortcut.com/blog/dont-deploy-on-frida-3-other-unwritten-rules-of-software-engineering