### PR TITLE
Prepare v0.13.1

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -22,7 +22,7 @@
       "project_repo_name": "finch",
       "project_readthedocs_name": "finch",
       "project_short_description": "A Web Processing Service for Climate Indicators.",
-      "version": "0.13.0",
+      "version": "0.13.1-dev.0",
       "open_source_license": "Apache Software License 2.0",
       "http_port": "5000",
       "use_pytest": "y",

--- a/.cruft.json
+++ b/.cruft.json
@@ -22,7 +22,7 @@
       "project_repo_name": "finch",
       "project_readthedocs_name": "finch",
       "project_short_description": "A Web Processing Service for Climate Indicators.",
-      "version": "0.13.1-dev.0",
+      "version": "0.13.1",
       "open_source_license": "Apache Software License 2.0",
       "http_port": "5000",
       "use_pytest": "y",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
         additional_dependencies: [ 'flake8-rst-docstrings==0.3.0' ]
         args: [ '--config=.flake8' ]
   - repo: https://github.com/jendrikseipp/vulture
-    rev: 'v2.14'
+    rev: v2.14
     hooks:
       - id: vulture
   - repo: https://github.com/PyCQA/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,17 +37,17 @@ repos:
       - id: rst-inline-touching-normal
       - id: text-unicode-replacement-char
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
       - id: black
         args: [ '--target-version=py310' ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.9.6
     hooks:
       - id: ruff
         args: [ '--fix', '--show-fixes' ]
   - repo: https://github.com/pylint-dev/pylint
-    rev: v3.3.3
+    rev: v3.3.4
     hooks:
       - id: pylint
         args: [ '--rcfile=.pylintrc.toml', '--errors-only', '--jobs=0', '--disable=import-error' ]
@@ -62,7 +62,7 @@ repos:
     hooks:
       - id: vulture
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 6.0.0
     hooks:
       - id: isort
   - repo: https://github.com/nbQA-dev/nbQA
@@ -70,13 +70,13 @@ repos:
     hooks:
       - id: nbqa-black
         args: [ '--target-version=py310' ]
-        additional_dependencies: [ 'black==24.10.0' ]
+        additional_dependencies: [ 'black==25.1.0' ]
       - id: nbqa-pyupgrade
         args: [ '--py310-plus' ]
         additional_dependencies: [ 'pyupgrade==3.19.1' ]
       - id: nbqa-isort
         args: [ '--settings-file=pyproject.toml' ]
-        additional_dependencies: [ 'isort==5.13.2' ]
+        additional_dependencies: [ 'isort==6.0.0' ]
   - repo: https://github.com/kynan/nbstripout
     rev: 0.8.1
     hooks:
@@ -87,10 +87,10 @@ repos:
     rev: v0.3.9
     hooks:
       - id: blackdoc
-        additional_dependencies: [ 'black==24.10.0' ]
+        additional_dependencies: [ 'black==25.1.0' ]
       - id: blackdoc-autoupdate-black
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.30.0
+    rev: 0.31.1
     hooks:
       - id: check-github-workflows
       - id: check-readthedocs

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+v0.13.1 (2025-02-13)
+--------------------
+
+* Allowed for the use of four (4) emissions scenarios in the `ensemble_percentiles` process.
+
 v0.13.0 (2025-01-20)
 --------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM condaforge/mambaforge
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PIP_ROOT_USER_ACTION=ignore
 LABEL org.opencontainers.image.authors="https://github.com/bird-house/finch"
-LABEL Description="Finch WPS" Vendor="Birdhouse" Version="0.13.0"
+LABEL Description="Finch WPS" Vendor="Birdhouse" Version="0.13.1-dev.0"
 
 # Set the working directory to /code
 WORKDIR /code

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM condaforge/mambaforge
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PIP_ROOT_USER_ACTION=ignore
 LABEL org.opencontainers.image.authors="https://github.com/bird-house/finch"
-LABEL Description="Finch WPS" Vendor="Birdhouse" Version="0.13.1-dev.0"
+LABEL Description="Finch WPS" Vendor="Birdhouse" Version="0.13.1"
 
 # Set the working directory to /code
 WORKDIR /code

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,7 +1,6 @@
 name: finch
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - python >=3.10,<3.13
   - pywps >=4.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ target-version = [
 ]
 
 [tool.bumpversion]
-current_version = "0.13.1-dev.0"
+current_version = "0.13.1"
 commit = true
 commit_args = "--no-verify"
 tag = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ target-version = [
 ]
 
 [tool.bumpversion]
-current_version = "0.13.0"
+current_version = "0.13.1-dev.0"
 commit = true
 commit_args = "--no-verify"
 tag = false

--- a/src/finch/__version__.py
+++ b/src/finch/__version__.py
@@ -6,4 +6,4 @@
 
 __author__ = """David Huard"""
 __email__ = "huard.david@ouranos.ca"
-__version__ = "0.13.0"
+__version__ = "0.13.1-dev.0"

--- a/src/finch/__version__.py
+++ b/src/finch/__version__.py
@@ -6,4 +6,4 @@
 
 __author__ = """David Huard"""
 __email__ = "huard.david@ouranos.ca"
-__version__ = "0.13.1-dev.0"
+__version__ = "0.13.1"


### PR DESCRIPTION
## Overview

Changes:

* Prepared the next patch version (v0.13.1; for release on 2025-02-13)
* Fixed a bad conda configuration
* Updated pre-commit hooks
