### PR TITLE
Use miniforge3, adapt to pytest v9.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,10 +85,6 @@ docs/build/
 docs/source/output-sanitize.cfg
 docs/source/references.bib
 
-# External Sources
-#src/external
-src/
-
 # tests
 *.log
 *.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,17 +50,17 @@ repos:
       - id: rst-inline-touching-normal
       - id: text-unicode-replacement-char
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.3.1
+    rev: 26.5.1
     hooks:
       - id: black
         args: [ '--target-version=py310' ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.9
+    rev: v0.15.20
     hooks:
       - id: ruff-check
         args: [ '--fix', '--show-fixes' ]
   - repo: https://github.com/pylint-dev/pylint
-    rev: v4.0.5
+    rev: v4.0.6
     hooks:
       - id: pylint
         args: [ '--rcfile=.pylintrc.toml', '--errors-only', '--jobs=0', '--disable=import-error' ]
@@ -68,14 +68,14 @@ repos:
     rev: 7.3.0
     hooks:
       - id: flake8
-        additional_dependencies: [ 'flake8-rst-docstrings==0.3.0' ]
+        additional_dependencies: [ 'flake8-rst-docstrings==0.4.0' ]
         args: [ '--config=.flake8' ]
   - repo: https://github.com/jendrikseipp/vulture
     rev: v2.16
     hooks:
       - id: vulture
   - repo: https://github.com/PyCQA/isort
-    rev: 8.0.1
+    rev: 9.0.0a3
     hooks:
       - id: isort
   - repo: https://github.com/nbQA-dev/nbQA
@@ -83,13 +83,13 @@ repos:
     hooks:
       - id: nbqa-black
         args: [ '--target-version=py310' ]
-        additional_dependencies: [ 'black==26.1.0' ]
+        additional_dependencies: [ 'black==26.5.1' ]
       - id: nbqa-pyupgrade
         args: [ '--py310-plus' ]
         additional_dependencies: [ 'pyupgrade==3.21.2' ]
       - id: nbqa-isort
         args: [ '--settings-file=pyproject.toml' ]
-        additional_dependencies: [ 'isort==7.0.0' ]
+        additional_dependencies: [ 'isort==9.0.0a3' ]
   - repo: https://github.com/kynan/nbstripout
     rev: 0.9.1
     hooks:
@@ -100,15 +100,15 @@ repos:
     rev: v0.4.6
     hooks:
       - id: blackdoc
-        additional_dependencies: [ 'black==26.3.1' ]
+        additional_dependencies: [ 'black==26.5.1' ]
       - id: blackdoc-autoupdate-black
   - repo: https://github.com/numpy/numpydoc
-    rev: v1.10.0
+    rev: v1.11.0rc0
     hooks:
       - id: numpydoc-validation
-        exclude: ^docs/|^tests/|.*\/_.*\.py$
+        exclude: ^docs/|^tests/|.*\/_.*\.py$|^conftest.py|^src/finch/processes/
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.1
+    rev: 0.37.4
     hooks:
       - id: check-github-workflows
       - id: check-readthedocs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,6 +102,11 @@ repos:
       - id: blackdoc
         additional_dependencies: [ 'black==26.3.1' ]
       - id: blackdoc-autoupdate-black
+  - repo: https://github.com/numpy/numpydoc
+    rev: v1.10.0
+    hooks:
+      - id: numpydoc-validation
+        exclude: ^docs/|^tests/|.*\/_.*\.py$
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.37.1
     hooks:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+v0.14.0 (unreleased)
+--------------------
+
+* Base image for `Dockerfile` changed from `condaforge/mambaforge` to `condaforge/miniforge3`.
+* Removed `pytest-flake8` from development dependencies (incompatible with `pytest` v9.x).
+* Added `numpydoc-validation` to linters; Reformatted several function and class docstrings.
+
 v0.13.2 (2025-06-05)
 --------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM condaforge/mambaforge
+FROM condaforge/miniforge3
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PIP_ROOT_USER_ACTION=ignore
 LABEL org.opencontainers.image.authors="https://github.com/bird-house/finch"
@@ -10,10 +10,13 @@ WORKDIR /code
 
 # Create conda environment
 COPY environment.yml .
-RUN mamba env create -n finch -f environment.yml && mamba install -n finch gunicorn && mamba clean --all --yes
+RUN mamba env create -n finch -f environment.yml && mamba install -n finch -c conda-forge gunicorn && mamba clean --all --yes
 
 # Add the project conda environment to the path
-ENV PATH=/opt/conda/envs/finch/bin:$PATH
+ENV PATH="/opt/conda/envs/finch/bin:$PATH"
+
+# For pyproj, to avoid error "PROJ: proj_create_from_database: Open of /opt/conda/envs/finch/share/proj failed"
+ENV PROJ_DATA="/opt/conda/envs/finch/share/proj"
 
 # Copy WPS project
 COPY . /code
@@ -25,7 +28,7 @@ RUN pip install . --no-deps
 EXPOSE 5000
 
 # Specify a non-root user to run the application
-RUN useradd --create-home --shell /bin/bash --uid 1000 nonroot && mkdir -p /tmp/matplotlib && chown -R nonroot:nonroot /code /home/nonroot /tmp/matplotlib /opt/conda/envs/finch
+RUN useradd --create-home --shell /bin/bash --uid 1001 nonroot && mkdir -p /tmp/matplotlib && chown -R nonroot:nonroot /code /home/nonroot /tmp/matplotlib /opt/conda/envs/finch
 USER nonroot
 ENV MPLCONFIGDIR=/tmp/matplotlib
 

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - cftime >=1.4.1
   - cf_xarray >=0.9.3
   - click >=8.1.7
-  - clisops >=0.16.2
+  - clisops >=0.16.2,!=0.18.0
   - dask >=2023.5.1
   - distributed
   - geopandas >=1.0

--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
   - xarray >=2023.11.0
   - xclim >=0.61,<0.62 # remember to match xclim version in pyproject.toml as well
   - xesmf >=0.8.2,!=0.8.8
-  - xsdba =0.6.1   # remember to match xsdba version in pyproject.toml as well
+  - xsdba >=0.6,<0.7   # remember to match xsdba version in pyproject.toml as well
   - xscen >=0.15,<0.16  # remember to match xscen version in pyproject.toml as well
   # Temporary fixes
   - fastprogress <1.1  # FIXME: Temporary fix following https://github.com/intake/intake-esm/pull/773. Remove when intake-esm is updated in xscen.

--- a/environment.yml
+++ b/environment.yml
@@ -53,7 +53,6 @@ dependencies:
   - pylint >=3.3.3
   - pytest >=8.0.0
   - pytest-cov >=5.0.0
-  - pytest-flake8
   - ruff >=0.14.0
   - watchdog >=4.0.0
   - yamllint >=1.26.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "cf-xarray >=0.9.3",
   "cftime >=1.4.1",
   "click >=8.1.7",
-  "clisops >=0.16.2",
+  "clisops >=0.16.2,!=0.18.0",
   "dask[complete] >=2023.5.1",
   "geopandas >=1.0",
   "jinja2 >=3.1.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,6 +245,7 @@ checks = [
   "ES01", # "No extended summary found"
   "EX01", # "No examples section found"
   "GL06", # "Found unknown section \"{section}\""
+  "GL08", # "The object does not have a docstring"
   "SA01", # "See Also section not found",
   "SS01" # "No summary found"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,6 @@ dev = [
   "pylint >=3.3.3",
   "pytest >=8.0.0",
   "pytest-cov >=5.0.0",
-  "pytest-flake8",
   "ruff >=0.14.0",
   "vulture >=2.14",
   "watchdog >=4.0.0"

--- a/src/finch/processes/ensemble_utils.py
+++ b/src/finch/processes/ensemble_utils.py
@@ -226,7 +226,8 @@ def get_datasets(
 
 
 def _formatted_coordinate(value) -> str | None:
-    """Return the first float value.
+    """
+    Return the first float value.
 
     The value can be a comma separated list of floats or a single float.
     """
@@ -242,7 +243,8 @@ def _formatted_coordinate(value) -> str | None:
 def make_output_filename(
     process: Process, inputs: list[PywpsInput], scenario=None, dataset=None
 ):
-    """Return a filename for the process's output, depending on its inputs.
+    """
+    Return a filename for the process's output, depending on its inputs.
 
     The scenario part of the filename can be overriden.
     """
@@ -286,7 +288,8 @@ def make_output_filename(
 def uses_accepted_netcdf_variables(
     indicator: Indicator, available_variables: set
 ) -> bool:
-    """Determine if indicator uses accepted NetCDF variables.
+    """
+    Determine if indicator uses accepted NetCDF variables.
 
     Returns
     -------
@@ -329,7 +332,8 @@ def make_indicator_inputs(
 
 
 def make_file_groups(files_list: list[Path], variables: set) -> list[dict[str, Path]]:
-    """Group files by filenames, changing only the netcdf variable name.
+    """
+    Group files by filenames, changing only the netcdf variable name.
 
     The list of variable names to search must be given.
     """

--- a/src/finch/processes/ensemble_utils.py
+++ b/src/finch/processes/ensemble_utils.py
@@ -136,7 +136,8 @@ def file_is_required(
 
 
 def iter_remote(cat: TDSCatalog, depth: int = -1):
-    """Create generator listing all datasets recursively in a TDSCatalog.
+    """
+    Create generator listing all datasets recursively in a TDSCatalog.
 
     The search is limited to a certain depth if `depth` >= 0.
     """
@@ -149,7 +150,8 @@ def iter_remote(cat: TDSCatalog, depth: int = -1):
 
 
 def iter_local(root: Path, depth: int = -1, pattern: str = "*.nc"):
-    """Create generator listing all datasets recursively in a local directory.
+    """
+    Create generator listing all datasets recursively in a local directory.
 
     The search is limited to a certain depth if `depth` >= 0.
     The path can be given relative to the root finch code repo.
@@ -188,19 +190,20 @@ def get_datasets(
     scenario: str | None = None,
     models: list[str] | None = None,
 ) -> list[PywpsInput]:
-    """Parse a directory to find files and filters the list to return only the needed ones, as resource inputs.
+    """
+    Parse a directory to find files and filters the list to return only the needed ones, as resource inputs.
 
     Parameters
     ----------
     dsconf : DatasetConfiguration
         The dataclass defining a specific ensemble dataset.
-    workdir: str
+    workdir : str
         The working directory where files will be downloaded if needed.
-    variables: list of strings
+    variables : list of strings
         A list of the needed variables
-    scenario: str
+    scenario : str
         The name of the scenario (experiment), rcps or ssps.
-    models: list of strings
+    models : list of strings
         A list of the requested models (or name of a models sublist)
     """
     if dsconf.local:

--- a/src/finch/processes/subset.py
+++ b/src/finch/processes/subset.py
@@ -129,7 +129,8 @@ def finch_subset_gridpoint(
 def finch_subset_bbox(
     process: Process, netcdf_inputs: list[ComplexInput], request_inputs: RequestInputs
 ) -> list[Path]:
-    """Parse wps `request_inputs` based on their name and subset `netcdf_inputs`.
+    """
+    Parse wps `request_inputs` based on their name and subset `netcdf_inputs`.
 
     The expected names of the request_inputs are as followed (taken from `wpsio.py`):
      - lat0: Latitude coordinate
@@ -204,7 +205,8 @@ def finch_subset_bbox(
 
 
 def extract_shp(path):
-    """Return a geopandas-compatible path to the shapefile stored in a zip archive.
+    """
+    Return a geopandas-compatible path to the shapefile stored in a zip archive.
 
     If multiple shapefiles are included, return only the first one found.
 

--- a/src/finch/processes/subset.py
+++ b/src/finch/processes/subset.py
@@ -25,7 +25,7 @@ from .utils import (
 LOGGER = logging.getLogger("PYWPS")
 
 
-def make_subset_file_name(resource, kind="sub"):
+def make_subset_file_name(resource, kind: str = "sub"):
     """Create output file name."""
     if resource.prop == "file":
         p = Path(resource.file)
@@ -46,7 +46,8 @@ def make_subset_file_name(resource, kind="sub"):
 def finch_subset_gridpoint(
     process: Process, netcdf_inputs: list[ComplexInput], request_inputs: RequestInputs
 ) -> list[Path]:
-    """Parse wps `request_inputs` based on their name and subset `netcdf_inputs`.
+    """
+    Parse wps `request_inputs` based on their name and subset `netcdf_inputs`.
 
     The expected names of the inputs are as followed (taken from `wpsio.py`):
      - lat: Latitude coordinate, can be a comma separated list of floats
@@ -210,12 +211,12 @@ def extract_shp(path):
     Parameters
     ----------
     path : Path
-      Path to zip archive holding shapefile.
+        Path to zip archive holding shapefile.
 
     Returns
     -------
     str
-      zip:///<path to zip file>!<relative path to shapefile>
+        zip:///<path to zip file>!<relative path to shapefile>
     """
     from zipfile import ZipFile
 
@@ -232,7 +233,8 @@ def finch_average_shape(
     netcdf_inputs: list[ComplexInput],
     request_inputs: RequestInputs,
 ) -> list[Path] | None:
-    """Parse wps `request_inputs` based on their name and average `netcdf_inputs`.
+    """
+    Parse wps `request_inputs` based on their name and average `netcdf_inputs`.
 
     The expected names of the request_inputs are as followed (taken from `wpsio.py`):
      - shape: Polygon contour to average the data over.
@@ -298,7 +300,8 @@ def finch_subset_shape(
     netcdf_inputs: list[ComplexInput],
     request_inputs: RequestInputs,
 ) -> list[Path]:
-    """Parse wps `request_inputs` based on their name and subset `netcdf_inputs`.
+    """
+    Parse wps `request_inputs` based on their name and subset `netcdf_inputs`.
 
     The expected names of the request_inputs are as followed (taken from `wpsio.py`):
      - shape: Polygon contour to subset the data with.

--- a/src/finch/processes/utils.py
+++ b/src/finch/processes/utils.py
@@ -83,12 +83,12 @@ class DatasetConfiguration:
 
     Attributes
     ----------
-    path: str
+    path : str
         The path (or url) to the root directory where to search for the data.
-    pattern: str
+    pattern : str
         The pattern of the filenames. Must include at least : "variable", "scenario" and "model".
         Patterns must be understandable by :py:func:`parse.parse`.
-    local: bool
+    local : bool
         Whether the path points to a local directory or a remote THREDDS catalog.
     depth : int
         The depth to which search for files below the directory. < 0 will search recursively.
@@ -145,7 +145,7 @@ def log_file_path(process: Process) -> Path:
 def write_log(
     process: Process,
     message: str,
-    level=logging.INFO,
+    level: int = logging.INFO,
     *,
     process_step: str | None = None,
     subtask_percentage: int | None = None,
@@ -193,7 +193,7 @@ def write_log(
             pass
 
 
-def get_attributes_from_config():
+def get_attributes_from_config() -> dict[str, str | bool]:
     """Get all explicitly passed metadata attributes from the config in section finch:metadata."""
     # Remove all "defaults", only keep explicitly-passed options
     # This works because we didn't define any defaults for this section.
@@ -387,7 +387,7 @@ def drs_filename(ds: xr.Dataset, variable: str | None = None):
 def try_opendap(
     input: ComplexInput,
     *,
-    chunks="auto",
+    chunks: str | None = "auto",
     decode_times=True,
     chunk_dims=None,
     logging_function=lambda message: None,
@@ -872,11 +872,18 @@ def update_history(
 
 
 def valid_filename(name: Path | str) -> Path | str:
-    """Remove unsupported characters from a filename.
+    """
+    Remove unsupported characters from a filename.
+
+    Parameters
+    ----------
+    name : str or Path
+        Filename.
 
     Returns
     -------
     str or Path
+        Sanitized filename.
 
     Examples
     --------

--- a/src/finch/processes/utils.py
+++ b/src/finch/processes/utils.py
@@ -389,7 +389,7 @@ def drs_filename(ds: xr.Dataset, variable: str | None = None):
 def try_opendap(
     input: ComplexInput,
     *,
-    chunks: str | None = "auto",
+    chunks: Any = "auto",
     decode_times=True,
     chunk_dims=None,
     logging_function=lambda message: None,

--- a/src/finch/processes/utils.py
+++ b/src/finch/processes/utils.py
@@ -79,7 +79,8 @@ def get_virtual_modules():
 
 @dataclass
 class DatasetConfiguration:
-    """Dataset Configuration class.
+    """
+    Dataset Configuration class.
 
     Attributes
     ----------
@@ -150,7 +151,8 @@ def write_log(
     process_step: str | None = None,
     subtask_percentage: int | None = None,
 ):
-    """Log the process status.
+    """
+    Log the process status.
 
      - With the logging module
      - To a log file stored in the process working directory
@@ -392,7 +394,8 @@ def try_opendap(
     chunk_dims=None,
     logging_function=lambda message: None,
 ) -> xr.Dataset:
-    """Try to open the file as an OPeNDAP url and chunk it.
+    """
+    Try to open the file as an OPeNDAP url and chunk it.
 
     By default, chunks are to be determined by xarray/dask.
     If `chunks=None` or `chunks_dims` is given, finch rechunks the dataset according to
@@ -453,7 +456,8 @@ def process_threaded(function: Callable, inputs: Iterable):
 
 
 def chunk_dataset(ds, max_size=1000000, chunk_dims=None):
-    """Ensure the chunked size of a xarray.Dataset is below a certain size.
+    """
+    Ensure the chunked size of a xarray.Dataset is below a certain size.
 
     Cycle through the dimensions, divide the chunk size by 2 until criteria is met.
     If chunk_dims is given, limits the chunking to those dimensions, if they are
@@ -505,7 +509,8 @@ def make_metalink_output(
 
 
 def is_opendap_url(url):
-    """Check if a provided url is an OpenDAP url.
+    """
+    Check if a provided url is an OpenDAP url.
 
     The DAP Standard specifies that a specific tag must be included in the
     Content-Description header of every request. This tag is one of: {"dods-dds", "dods-das", "dods-data", "dods-error"}
@@ -544,11 +549,12 @@ def single_input_or_none(inputs, identifier) -> Any | None:
 
 def netcdf_file_list_to_csv(
     netcdf_files: list[Path] | list[str],
-    output_folder,
-    filename_prefix,
+    output_folder: str | Path,
+    filename_prefix: str,
     csv_precision: int | None = None,
 ) -> tuple[list[Path], str]:
-    """Write csv files for a list of netcdf files.
+    """
+    Write csv files for a list of netcdf files.
 
     Produces one csv file per calendar type, along with a metadata folder in the output_folder.
     """
@@ -827,7 +833,8 @@ def update_history(
     new_name: str | None = None,
     **inputs_kws: xr.DataArray | xr.Dataset,
 ):
-    r"""Return a history string with the timestamped message and the combination of the history of all inputs.
+    r"""
+    Return a history string with the timestamped message and the combination of the history of all inputs.
 
     The new history entry is formatted as "[<timestamp>] <new_name>: <hist_str> - finch version : <finch version>."
 

--- a/src/finch/processes/wps_base.py
+++ b/src/finch/processes/wps_base.py
@@ -66,7 +66,8 @@ class FinchProcess(Process):
             raise ProcessError(f"Finch failed with {err!s}")
 
     def sentry_configure_scope(self, request):
-        """Add additional data to sentry error messages.
+        """
+        Add additional data to sentry error messages.
 
         When sentry is not initialized, this won't add any overhead.
         """

--- a/src/finch/processes/wps_ensemble_indices_bbox.py
+++ b/src/finch/processes/wps_ensemble_indices_bbox.py
@@ -14,7 +14,8 @@ LOGGER = logging.getLogger("PYWPS")
 
 
 class XclimEnsembleBboxBase(FinchProcess):
-    """Ensemble with bbox subset base class.
+    """
+    Ensemble with bbox subset base class.
 
     Set xci to the xclim indicator in order to have a working class.
     """

--- a/src/finch/processes/wps_ensemble_indices_point.py
+++ b/src/finch/processes/wps_ensemble_indices_point.py
@@ -14,7 +14,8 @@ LOGGER = logging.getLogger("PYWPS")
 
 
 class XclimEnsembleGridPointBase(FinchProcess):
-    """Ensemble with grid point subset base class.
+    """
+    Ensemble with grid point subset base class.
 
     Set xci to the xclim indicator in order to have a working class.
     """

--- a/src/finch/processes/wps_ensemble_indices_polygon.py
+++ b/src/finch/processes/wps_ensemble_indices_polygon.py
@@ -13,7 +13,8 @@ LOGGER = logging.getLogger("PYWPS")
 
 
 class XclimEnsemblePolygonBase(FinchProcess):
-    """Ensemble with polygon subset base class.
+    """
+    Ensemble with polygon subset base class.
 
     Set xci to the xclim indicator in order to have a working class.
     """

--- a/src/finch/processes/wps_xclim_indices.py
+++ b/src/finch/processes/wps_xclim_indices.py
@@ -29,7 +29,8 @@ LOGGER = logging.getLogger("PYWPS")
 
 
 class XclimIndicatorBase(FinchProcess):
-    """Dummy xclim indicator process class.
+    """
+    Dummy xclim indicator process class.
 
     Set xci to the xclim indicator in order to have a working class.
     """

--- a/src/finch/processes/wpsio.py
+++ b/src/finch/processes/wpsio.py
@@ -20,7 +20,8 @@ from .utils import PywpsInput, PywpsOutput, get_datasets_config
 
 
 def copy_io(io: PywpsInput | PywpsOutput, **kwargs) -> PywpsInput | PywpsOutput:
-    """Create a new input or output with modified parameters.
+    """
+    Create a new input or output with modified parameters.
 
     Use this if you want one of the inputs in this file, but want to modify it.
 

--- a/src/finch/wsgi.py
+++ b/src/finch/wsgi.py
@@ -12,7 +12,7 @@ if os.environ.get("SENTRY_DSN"):
     sentry_sdk.init(os.environ["SENTRY_DSN"])
 
 
-def create_app(cfgfiles: list[str] | None = None) -> Service:
+def create_app(cfgfiles: list[str] | str | None = None) -> Service:
     """
     Create PyWPS application.
 
@@ -26,11 +26,11 @@ def create_app(cfgfiles: list[str] | None = None) -> Service:
     pywps.app.Service.Service
         PyWPS application.
     """
-    config_files = [Path(__file__).parent.joinpath("default.cfg")]
+    config_files: list[str | Path] = [Path(__file__).parent.joinpath("default.cfg")]
     if isinstance(cfgfiles, str):
         cfgfiles = [cfgfiles]
     if cfgfiles:
-        config_files += cfgfiles
+        config_files.extend(cfgfiles)
     if "PYWPS_CFG" in os.environ:
         config_files.append(os.environ["PYWPS_CFG"])
     service = Service(cfgfiles=config_files)

--- a/src/finch/wsgi.py
+++ b/src/finch/wsgi.py
@@ -18,7 +18,7 @@ def create_app(cfgfiles: list[str] | str | None = None) -> Service:
 
     Parameters
     ----------
-    cfgfiles : list of str, optional
+    cfgfiles : str or list of str, optional
         Configuration files to use.
 
     Returns

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,6 @@ from xarray import DataArray
 from xclim.core.calendar import percentile_doy
 from xclim.testing.helpers import test_timeseries as timeseries
 
-import finch.processes
 import finch.wsgi
 from _common import CFG_FILE, client_for
 


### PR DESCRIPTION
## Overview

Changes:

* Updates the base docker image from `condaforge/mambaforge` to `condaforge/miniforge3`
* Updates dependency specs and remove pytest-flake8 from dev deps.
* Reformats multiple docstrings and adds numpydoc-validation to `pre-commit`.

## Additional Information

The `condaforge/mambaforge` image has been deprecated for quite some time. This is the suggested upgrade according to the maintainers.