### PR TITLE
avoid duplicate copies of docker layers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,6 +18,7 @@ finch.egg-info/
 .cache
 .pytest_cache
 conftest.py
+test*.*
 
 # PyCharm
 *.idea

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Install finch-wps
         run: |
           make install
+      - name: Install dev dependencies for tests
+        run: |
+          make develop
       - name: Check versions
         run: |
           python -m pip check

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ coverage.xml
 coverage
 htmlcov
 nosetests.xml
+test*.*
 
 # buildout
 bin

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,16 +2,22 @@
 Changelog
 =========
 
+unreleased
+--------------------
+
+* Update Docker build to employ only core packages (removed dev/doc from ``environment.yml``).
+* Optimized Dockerfile to avoid duplicating conda environment layer (and therefore duplicating size as well) when setting nonroot user.
+
 v0.13.2 (2025-06-05)
 --------------------
 
 * Allow calculations of 30-year averages on ensemble processes
-* Synchronized dependencies for `xclim` and `xscen`, placed pins on `numcodecs` to prevent issues with `zarr` and `dask`.
+* Synchronized dependencies for ``xclim`` and ``xscen``, placed pins on ``numcodecs`` to prevent issues with ``zarr`` and ``dask``.
 
 v0.13.1 (2025-02-13)
 --------------------
 
-* Allowed for the use of four (4) emissions scenarios in the `ensemble_percentiles` process.
+* Allowed for the use of four (4) emissions scenarios in the ``ensemble_percentiles`` process.
 
 v0.13.0 (2025-01-20)
 --------------------
@@ -19,59 +25,59 @@ v0.13.0 (2025-01-20)
 * Added support for Birdhouse Helper Bot (for bumping versions).
 * CI Actions and Python dependencies are now pinned to commit hashes.
 * Permissions have been set and restricted as needed for all workflows.
-* Pinned `cf-xarray` below v0.9.3.
-* Reformatted and renamed `CHANGES.rst` to `CHANGELOG.rst`.
+* Pinned ``cf-xarray`` below v0.9.3.
+* Reformatted and renamed ``CHANGES.rst`` to ``CHANGELOG.rst``.
 * Dropped support for Python 3.8 and 3.9. The supported versions are now Python 3.10, 3.11 and 3.12.
-* `black` has been updated to v2024.10.0, and coding conventions have been updated to Python3.10+.
-* Several dependencies now are pinned to baseline versions, including `anyascii`, `dask`, `ipython`, `matplotlib`, `nbsphinx` `numpy`, and `sphinxcontrib-bibtex`.
-* Added `xscen` dependency. Now used in spatial averaging of ensemble processes.
-* Updated the build system to use `flit` v3.9.0 (PEP 517 and PEP 621). Several configuration files have been migrated to `pyproject.toml` and `.flake8`.
-* `finch` now uses a src-based layout for the package. The `finch` package is now located in the `src` directory.
-* The pre-commit configuration has been updated to use `pre-commit` v3.5.0. Several hooks have been added, including `pygrep-hooks` (security fixes), `ruff` (code formatting), and `vulture` (dead code).
-* Documentation examples now build without warnings. ReadTheDocs is now configured to `fail_on_warning`.
-* `xclim` has been updated to v0.52.2.
+* ``black`` has been updated to v2024.10.0, and coding conventions have been updated to Python3.10+.
+* Several dependencies now are pinned to baseline versions, including ``anyascii``, ``dask``, ``ipython``, ``matplotlib``, ``nbsphinx``, ``numpy``, and ``sphinxcontrib-bibtex``.
+* Added ``xscen`` dependency. Now used in spatial averaging of ensemble processes.
+* Updated the build system to use ``flit`` v3.9.0 (PEP 517 and PEP 621). Several configuration files have been migrated to ``pyproject.toml`` and ``.flake8``.
+* ``finch`` now uses a src-based layout for the package. The ``finch`` package is now located in the ``src`` directory.
+* The pre-commit configuration has been updated to use ``pre-commit`` v3.5.0. Several hooks have been added, including ``pygrep-hooks`` (security fixes), ``ruff`` (code formatting), and ``vulture`` (dead code).
+* Documentation examples now build without warnings. ReadTheDocs is now configured to ``fail_on_warning``.
+* ``xclim`` has been updated to v0.52.2.
 * Modernized the documentation to reflect recent changes.
-* Added `pylint` to the linting checks and `pre-commit` steps.
+* Added ``pylint`` to the linting checks and ``pre-commit`` steps.
 * Added deployment workflows for PyPI and TestPyPI.
 * Synchronized more dependencies.
 
 v0.12.1 (2024-06-25)
 --------------------
 
-* Replaced `unidecode` with `anyascii` due to a licensing issue.
+* Replaced ``unidecode`` with ``anyascii`` due to a licensing issue.
 * Synchronized some dependencies across build systems.
-* Added a workaround in ``wps_geoseries_to_netcdf`` to handle a `pandas` v2.0 behaviour change.
+* Added a workaround in ``wps_geoseries_to_netcdf`` to handle a ``pandas`` v2.0 behaviour change.
 
 v0.12.0 (2024-03-25)
 --------------------
 
-* Renamed the installed package from `finch` to `birdhouse-finch`.
-* First release of the `birdhouse-finch` package on PyPI.
+* Renamed the installed package from ``finch`` to ``birdhouse-finch``.
+* First release of the ``birdhouse-finch`` package on PyPI.
 * Versioning now adheres to SemVer v2.0.0.
 * Added a Makefile recipe to the repository to evaluate notebooks while ignoring the output cells.
 * Cleaned up documentation to facilitate easier navigation.
 * Slightly reorganized the documentation for easier navigation.
 * Fast-forwarded the cookiecutter.
 * Fixed the ``Manifest.in`` to add all necessary files to wheel.
-* Removed references to files that have never existed (`apidoc`).
+* Removed references to files that have never existed (``apidoc``).
 * Cleaned up the setup code.
-* Added more files to be ignored in the `.gitignore` and in the `Manifest.in`.
+* Added more files to be ignored in the ``.gitignore`` and in the ``Manifest.in``.
 
 v0.11.4 (2023-12-20)
 --------------------
 
-* Fixed a bug that occurred when fixing a broken cftime-index with newer `cftime` versions.
+* Fixed a bug that occurred when fixing a broken cftime-index with newer ``cftime`` versions.
 * Placed pins on xarray and pandas to prevent future errors from changes to frequency codes.
 
 v0.11.3 (2023-08-23)
 --------------------
 
-* Updated ReadTheDocs to use the new mambaforge version (`2022.9`).
+* Updated ReadTheDocs to use the new mambaforge version (``2022.9``).
 * Addressed calls in GitHub Action usage that were emitting warnings.
-* Updated `MANIFEST.in` to include and exclude the relevant files for the source distribution.
-* Modified the `setup.py` to only include the files necessary in the wheel.
-* Updated `AUTHORS.rst` to list more contributors.
-* Removed namespace file (`__init__.py`) from tests to ensure that they aren't treated like an importable package.
+* Updated ``MANIFEST.in`` to include and exclude the relevant files for the source distribution.
+* Modified the ``setup.py`` to only include the files necessary in the wheel.
+* Updated ``AUTHORS.rst`` to list more contributors.
+* Removed namespace file (``__init__.py``) from tests to ensure that they aren't treated like an importable package.
 * Updated pre-commit hooks.
 * Sorted software requirements for legibility.
 * Removed Travis-CI shell script.
@@ -81,9 +87,9 @@ v0.11.2 (2023-07-27)
 
 * Added a Docker-based testing suite to the GitHub Workflows.
 * Added a wider range of Python versions to test against in the GitHub Workflows.
-* Migrated conda-build action from mamba-org/provision-with-micromamba to mamba-org/setup-micromamba.
+* Migrated conda-build action from ``mamba-org/provision-with-micromamba`` to ``mamba-org/setup-micromamba``.
 * Cleaned up the Dockerfile. Docker now pip-installs finch directly from the GitHub repository.
-* Finch now explicitly supports Python3.11.
+* Finch now explicitly supports Python 3.11.
 * Pinned Python below 3.12 on conda and removed pin on pint for ReadTheDocs builds.
 * Added a GitHub Workflow to bump the version number and to create tags from the version bumping process on dispatch.
 * Added a pre-commit hook for validating the ReadTheDocs configuration and GitHub Workflows.
@@ -94,9 +100,9 @@ v0.11.1 (2023-06-19)
 * Update to xclim 0.43.0.
 * Added xclim yml module support:
     - Added humidex days above calculation via yml module.
-    - Reimplmented streamflow indicators via yml module (adjust for xclim 0.41 breaking changes).
+    - Reimplemented streamflow indicators via yml module (adjust for xclim 0.41 breaking changes).
 * Fixed bug for CanDCS-U6 ensemble "26models" list.
-* Passing an empty string to `ensemble_percentiles` in ensemble processes will return the merged un-reduced ensemble. The different members are listed along the `realization` coordinates through raw names allowing for basic distinction between the input members.
+* Passing an empty string to ``ensemble_percentiles`` in ensemble processes will return the merged un-reduced ensemble. The different members are listed along the ``realization`` coordinates through raw names allowing for basic distinction between the input members.
 
 v0.11.0 (2023-06-13)
 --------------------
@@ -104,7 +110,7 @@ v0.11.0 (2023-06-13)
 * Fixed iter_local when depth > 0 to avoid all files to be considered twice
 * Revised documentation configuration on ReadTheDocs to leverage Anaconda (Mambaforge)
 * Minor adjustments to dependency configurations
-* Removed configuration elements handling from `finch start`. One can still pass custom config files, but all configuration defaults are handled by `finch/default.cfg` and the WSGI function. `jinja2` is not a dependency anymore.
+* Removed configuration elements handling from ``finch start``. One can still pass custom config files, but all configuration defaults are handled by ``finch/default.cfg`` and the WSGI function. ``jinja2`` is not a dependency anymore.
 
 v0.10.0 (2022-11-04)
 --------------------
@@ -160,7 +166,7 @@ v0.8.0 (2022-01-13)
 
 * Add ``hourly_to_daily`` process, converting hourly data to daily data using a reduction operation (sum, mean, max, min).
 * Upgrade to clisops 0.8.0 to accelerate spatial averages over regions.
-* Upgrade to xesmf 0.6.2 to fix spatial averaging bug not weighing correctly cells with varing areas.
+* Upgrade to xesmf 0.6.2 to fix spatial averaging bug not weighing correctly cells with varying areas.
 * Update to PyWPS 4.5.1 to allow the creation of recursive directories for outputs.
 
 Notes
@@ -176,7 +182,7 @@ v0.7.6 (2021-11-16)
 -------------------
 
 * Update to xclim 0.31
-* Added `SENTRY_ENV` configuration
+* Added ``SENTRY_ENV`` configuration
 * Possibility to pass multiple "rcp" inputs for ensemble processes.
 * Writing to netcdf is done only after calling ``load()`` to avoid locks occurring within dask calls to ``to_netcdf`` in multi-processing mode.
 * Add an ``average`` parameter to ensemble processes. When true, a spatial average is returned.
@@ -207,13 +213,13 @@ v0.7.3 (2021-04-13)
 v0.7.2 (2021-04-01)
 -------------------
 
-* Add `data_validation` and `cf_compliance` arguments for ensemble xclim processes.
+* Add ``data_validation`` and ``cf_compliance`` arguments for ensemble xclim processes.
 
 v0.7.1 (2021-03-25)
 -------------------
 
-* Add `data_validation` and `cf_compliance` arguments for xclim processes.
-* Skip `data_validation` checks for the BCCAQv2HeatWave process.
+* Add ``data_validation`` and ``cf_compliance`` arguments for xclim processes.
+* Skip ``data_validation`` checks for the BCCAQv2HeatWave process.
 
 v0.7.0 (2021-03-15)
 -------------------
@@ -236,12 +242,12 @@ v0.6.0 (2021-01-12)
 -------------------
 
 * fix to chunk regions of subsetted files
-* use `cruft` to propagate changes from the birdhouse cookiecutter
+* use ``cruft`` to propagate changes from the birdhouse cookiecutter
 * catch documentation build error earlier since doc build is part of regular CI build
 * catch tutorial notebooks out of sync with code earlier since also part of regular CI build
 * use mock imports to facilitate building docs
 * add partial support for xclim v0.21
-* add support for shapefiles in `subset_shape`
+* add support for shapefiles in ``subset_shape``
 
 v0.5.2 (2020-03-25)
 -------------------
@@ -264,7 +270,7 @@ v0.5.0 (2020-03-18)
 v0.4.1 (2020-03-12)
 -------------------
 
-* fix #103 (drs_filename) add defaults when `project_id` is unknown
+* fix #103 (drs_filename) add defaults when ``project_id`` is unknown
 * drs_filenames: use dash instead of underscores in variable names
 * fix #80 frequency attrs of computed datasets
 
@@ -285,7 +291,7 @@ v0.4.0 (2020-03-10)
 v0.3.x (2020-01-17)
 -------------------
 
-* Extract common inputs and outputs to wpsio.py
+* Extract common inputs and outputs to ``wpsio.py``
 * Speed up CSV creation
 * Explicitly close thread pool
 * Tests for CSV conversion
@@ -307,8 +313,8 @@ v0.2.6 (2019-12-04)
 
 * Notebooks are tested by Travis-CI
 * Bug fix
-* Update `xclim` to >= 0.12.2
-* Update `pywps` to > 4.2.3
+* Update ``xclim`` to >= 0.12.2
+* Update ``pywps`` to > 4.2.3
 
 v0.2.5 (2019-10-03)
 -------------------
@@ -329,7 +335,7 @@ v0.2.1 (2019-05-06)
 
 * Require Python>=3.6
 * Fix percentages in status update
-* Improve loggin
+* Improve logging
 
 v0.2.0 (2019-05-02)
 -------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,13 @@ ENV PIP_ROOT_USER_ACTION=ignore
 LABEL org.opencontainers.image.authors="https://github.com/bird-house/finch"
 LABEL Description="Finch WPS" Vendor="Birdhouse" Version="0.13.3-dev.3"
 
+# Specify a non-root user to run the application
+RUN useradd --create-home --shell /bin/bash --uid 1000 nonroot && mkdir -p /tmp/matplotlib && chown -R nonroot:nonroot /tmp/matplotlib
+
 # Set the working directory to /code
 WORKDIR /code
 
-# Create conda environment
+# Create conda environment (root-owned is fine, nonroot just needs read access)
 COPY environment.yml .
 RUN mamba env create -n finch -f environment.yml && mamba install -n finch gunicorn && mamba clean --all --yes
 
@@ -16,7 +19,7 @@ RUN mamba env create -n finch -f environment.yml && mamba install -n finch gunic
 ENV PATH=/opt/conda/envs/finch/bin:$PATH
 
 # Copy WPS project
-COPY . /code
+COPY --chown=nonroot:nonroot . /code
 
 # Install WPS project
 RUN pip install . --no-deps
@@ -24,8 +27,6 @@ RUN pip install . --no-deps
 # Start WPS service on port 5000 of 0.0.0.0
 EXPOSE 5000
 
-# Specify a non-root user to run the application
-RUN useradd --create-home --shell /bin/bash --uid 1000 nonroot && mkdir -p /tmp/matplotlib && chown -R nonroot:nonroot /code /home/nonroot /tmp/matplotlib /opt/conda/envs/finch
 USER nonroot
 ENV MPLCONFIGDIR=/tmp/matplotlib
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # Configuration
 APP_ROOT := $(abspath $(lastword $(MAKEFILE_LIST))/..)
 APP_NAME := finch
+# auto-updated by bump version
+APP_VERSION ?= 0.13.3-dev.3
+APP_REPO ?= birdhouse
 
 WPS_URL = http://localhost:5000
 
@@ -181,3 +184,10 @@ dist: clean ## build source and wheel package
 release: dist ## upload source and wheel packages
 	@echo "Uploading source and wheel packages ..."
 	@python -m flit publish dist/*
+
+## Docker targets:
+
+.PHONY: docker-build
+docker-build: ## build docker image
+	@echo "Building docker image ..."
+	@docker build -t "$(APP_REPO)/$(APP_NAME):$(APP_VERSION)" .

--- a/environment.yml
+++ b/environment.yml
@@ -1,3 +1,7 @@
+# WARNING:
+#   This enviroment definition should only contain packages required by Finch directly.
+#   For dev,docs or other support dependencies, refer to the relevant pyproject groups.
+#   This is important to keep the Docker image size small.
 name: finch
 channels:
   - conda-forge
@@ -34,31 +38,3 @@ dependencies:
   - xscen >=0.15,<0.16  # remember to match xscen version in pyproject.toml as well
   # Temporary fixes
   - fastprogress <1.1  # FIXME: Temporary fix following https://github.com/intake/intake-esm/pull/773. Remove when intake-esm is updated in xscen.
-  # Dev
-  - birdy >=0.8.1
-  - black >=26.1.0
-  - bump-my-version >=1.2.6
-  - coverage >=7.5.0
-  - cruft >=2.15.0
-  - flake8 >=7.3.0
-  - flake8-rst-docstrings >=0.4.0
-  - flit >=3.11.0,<4.0
-  - geojson
-  - lxml
-  - nbsphinx >=0.9.8
-  - nbval >=0.10.0
-  - owslib
-  - pip >=25.3.0
-  - pre-commit >=3.5.0
-  - pylint >=3.3.3
-  - pytest >=8.0.0
-  - pytest-cov >=5.0.0
-  - pytest-flake8
-  - ruff >=0.14.0
-  - watchdog >=4.0.0
-  - yamllint >=1.26.0
-  # Docs
-  - ipython >=8.5.0
-  - matplotlib-base >=3.5.0
-  - sphinx >=9.0.0
-  - sphinxcontrib-bibtex >=2.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,11 @@ serialize = [
 ]
 
 [[tool.bumpversion.files]]
+filename = "Makefile"
+search = "APP_VERSION ?= \"{current_version}\""
+replace = "APP_VERSION ?= \"{new_version}\""
+
+[[tool.bumpversion.files]]
 filename = "src/finch/__version__.py"
 search = "__version__ = \"{current_version}\""
 replace = "__version__ = \"{new_version}\""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,7 +272,7 @@ override_SS05 = [
 addopts = [
   "--color=yes",
   "--strict-markers",
-  "--tb=native",
+  "--tb=native"
 ]
 python_files = ["test_*.py"]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -273,7 +273,6 @@ addopts = [
   "--color=yes",
   "--strict-markers",
   "--tb=native",
-  "-p no:flake8"  # avoid auto-detect, run flake8 separately to avoid incompatibility with pytest>=9 and pytest-flake8
 ]
 python_files = ["test_*.py"]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -273,7 +273,7 @@ addopts = [
   "--color=yes",
   "--strict-markers",
   "--tb=native",
-  "-p no:flake8"  # avoid auto-detect, run flake8 separately to avoid incompatibility with pytest>=9 and pytest-flake8
+  "-p no:flake8" # avoid auto-detect, run flake8 separately to avoid incompatibility with pytest>=9 and pytest-flake8
 ]
 python_files = ["test_*.py"]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,6 @@ dev = [
   "pylint >=3.3.3",
   "pytest >=8.0.0",
   "pytest-cov >=5.0.0",
-  "pytest-flake8",
   "ruff >=0.14.0",
   "vulture >=2.14",
   "watchdog >=4.0.0"
@@ -273,7 +272,8 @@ override_SS05 = [
 addopts = [
   "--color=yes",
   "--strict-markers",
-  "--tb=native"
+  "--tb=native",
+  "-p no:flake8"  # avoid auto-detect, run flake8 separately to avoid incompatibility with pytest>=9 and pytest-flake8
 ]
 python_files = ["test_*.py"]
 markers = [


### PR DESCRIPTION
## Overview

Reworks the docker command to avoid duplicate copy of file contents.
Because of the introduced `chown nonroot`, that basically forces the docker layer to cache all installed package files twice!

```
birdhouse/finch:version-0.13.2                  289b1b21b679       2.58GB
birdhouse/finch:0.13.3-dev.3                    0e7982021ae3       4.85GB  <---
birdhouse/finch:0.13.3-dev.3-with-chown-copy    e94cb8840170       2.77GB
```

The update uses a preemptive user creation and then `COPY --chown` with that user to return close to the original size (assumed the diff is from other package artifacts).


I also attempted removing unnecessary dev/doc deps from `environment.yml` to reduce size (since it is used for installation in the docker).
However, many doc deps (`sphinx` and co.) remain. I suspect this is caused by https://github.com/geopython/pywps/blob/main/environment.yml which also includes dev/doc packages unnecessarily.

Normally (like in https://github.com/crim-ca/weaver/blob/307478adfb1a220cc57ced5e32c74ec6431f1679/requirements.txt#L122 does), a **pip** install of `pywps` will NOT include the dev/doc packages (I can confirm this in the Weaver docker image). However, because `environment.yml` is used in `finch` with conda-forge packages, I assume https://anaconda.org/channels/conda-forge/packages/pywps/overview is used instead of the pypi release, and that must build using it corresponding https://github.com/geopython/pywps/blob/main/environment.yml including dev/doc.

I can find the links this way:
```shell
docker run --rm birdhouse/finch:0.13.3-dev.3-with-chown-copy bash -lc 'python - <<"PY"
import glob, json, os
meta = "/opt/conda/envs/finch/conda-meta"
# Is sphinx installed?
sphinx = sorted(glob.glob(os.path.join(meta, "sphinx-*.json")))
print(f"sphinx_installed={bool(sphinx)}")
if sphinx:
    print("sphinx_pkg=", os.path.basename(sphinx[0]))
# Which installed packages declare sphinx as dependency?
parents = []
for fp in glob.glob(os.path.join(meta, "*.json")):
    with open(fp, "r", encoding="utf-8") as f:
        data = json.load(f)
    deps = data.get("depends", []) or []
    if any(d.split()[0] == "sphinx" for d in deps):
        parents.append((data.get("name"), data.get("version"), os.path.basename(fp)))
print("parents_of_sphinx:")
for p in sorted(parents):
    print(" -", p[0], p[1], p[2])
PY'
```
```shell
sphinx_installed=True
sphinx_pkg= sphinx-9.1.0-pyhd8ed1ab_0.json
parents_of_sphinx:
 - pywps 4.7.0 pywps-4.7.0-pyhd8ed1ab_0.json
 - sphinxcontrib-applehelp 2.0.0 sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_1.json
 - sphinxcontrib-devhelp 2.0.0 sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_1.json
 - sphinxcontrib-htmlhelp 2.1.0 sphinxcontrib-htmlhelp-2.1.0-pyhd8ed1ab_1.json
 - sphinxcontrib-qthelp 2.0.0 sphinxcontrib-qthelp-2.0.0-pyhd8ed1ab_1.json
 - sphinxcontrib-serializinghtml 2.0.0 sphinxcontrib-serializinghtml-2.0.0-pyhd8ed1ab_0.json
```


## Changes:

* Update Docker build to employ only core packages (removed dev/doc from ``environment.yml``).
* Optimized Dockerfile to avoid duplicating conda environment layer (and therefore duplicating size as well) when setting nonroot user.
* Fixed the `CHANGELOG.rst` rendering (not using double code quotes)

## Related Issue / Discussion

## Additional Information

@Zeitsperre @cehbrecht
I recommend removing the dev/doc references from pywps's `environment.yml` altogether to remove unnecessary packages at runtime for all users relying on conda-forge release.

In the meantime, a patch can be applied locally by doing:
```diff
dependencies:
  - python >=3.11,<3.15
  - pip >=26.1.0
- - pywps >=4.6
+ - pip:
+   - pywps >=4.6 
```
