### PR TITLE
remove sphinx via pywps workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /code
 
 # Create conda environment (root-owned is fine, nonroot just needs read access)
 COPY environment.yml .
-RUN mamba env create -n finch -f environment.yml && mamba install -n finch gunicorn && mamba clean --all --yes
+RUN mamba env create -n finch -f environment.yml && mamba clean --all --yes
 
 # Add the project conda environment to the path
 ENV PATH=/opt/conda/envs/finch/bin:$PATH

--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - distributed
   - fiona >=0.10
   - geopandas >=1.0
+  - gunicorn>=23.0.0
   - jinja2 >=3.1.4
   - netcdf4
   - numpy >=1.25.0
@@ -39,5 +40,4 @@ dependencies:
   # Temporary fixes
   - fastprogress <1.1  # FIXME: Temporary fix following https://github.com/intake/intake-esm/pull/773. Remove when intake-esm is updated in xscen.
   - pip:
-    - gunicorn>=23.0.0
     - pywps >=4.6  # workaround to avoid installing its dev/doc dependencies embedded in its own environment.yml

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - clisops >=0.16.2
   - dask >=2023.5.1
   - distributed
+  - fiona >=0.10
   - geopandas >=1.0
   - jinja2 >=3.1.4
   - netcdf4
@@ -24,7 +25,6 @@ dependencies:
   - parse >=1.20
   - psutil >=6.0.0
   - python-slugify >=8.0
-  - pywps >=4.6
   - pyyaml >=6.0.1
   - scipy >=1.9.0
   - sentry-sdk
@@ -38,3 +38,6 @@ dependencies:
   - xscen >=0.15,<0.16  # remember to match xscen version in pyproject.toml as well
   # Temporary fixes
   - fastprogress <1.1  # FIXME: Temporary fix following https://github.com/intake/intake-esm/pull/773. Remove when intake-esm is updated in xscen.
+  - pip:
+    - gunicorn>=23.0.0
+    - pywps >=4.6  # workaround to avoid installing its dev/doc dependencies embedded in its own environment.yml


### PR DESCRIPTION
## Overview

Builds on top of #544 with the indicated PyWPS workaround.
Using the same strategy, we can check that Sphinx is indeed skipped:
```shell
docker run --rm birdhouse/finch:0.13.3-pywps-workaround bash -lc 'python - <<"PY"
import glob, json, os
meta = "/opt/conda/envs/finch/conda-meta"
# Is sphinx installed?
sphinx = sorted(glob.glob(os.path.join(meta, "sphinx-*.json")))
print(f"sphinx_installed={bool(sphinx)}")
if sphinx:
    print("sphinx_pkg=", os.path.basename(sphinx[0]))
# Which installed packages declare sphinx as dependency?
parents = []
for fp in glob.glob(os.path.join(meta, "*.json")):
    with open(fp, "r", encoding="utf-8") as f:
        data = json.load(f)
    deps = data.get("depends", []) or []
    if any(d.split()[0] == "sphinx" for d in deps):
        parents.append((data.get("name"), data.get("version"), os.path.basename(fp)))
print("parents_of_sphinx:")
for p in sorted(parents):
    print(" -", p[0], p[1], p[2])
PY'
```

```
sphinx_installed=False
parents_of_sphinx:
```

Diff result:
```
birdhouse/finch:version-0.13.2                  289b1b21b679       2.58GB
birdhouse/finch:0.13.3-dev.3                    0e7982021ae3       4.85GB
birdhouse/finch:0.13.3-dev.3-with-chown-copy    e94cb8840170       2.77GB
birdhouse/finch:0.13.3-pywps-workaround         9a84204b6b2d       2.68GB

```

Changes:

* Moved `pywps` under `pip` sub-package install
* Added `gunicorn` to the list
  - `pywps` was installing it anyway, so rely on `environment.yml` to provide it rather than a separate `mamba install` 
  - `pywps` install via `pip` fails if not provided

## Related Issue / Discussion

## Additional Information

Links to other issues or sources.
