### PR TITLE
Allow min_members parameter use

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,9 @@
 =========
 Changelog
 =========
+v0.14.0 (unreleased)
+---------------------
+* Exposed a new input parameter `min_members` for ensemble processes, allowing users to specify the minimum number of ensemble members required for calculations. This allows users to ensure that results are only produced when a sufficient number of members are available, enhancing the reliability of the output.
 
 v0.13.2 (2025-06-05)
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,10 +4,6 @@ Changelog
 v0.14.0 (unreleased)
 ---------------------
 * Exposed a new input parameter `min_members` for ensemble processes, allowing users to specify the minimum number of ensemble members required for calculations. This allows users to ensure that results are only produced when a sufficient number of members are available, enhancing the reliability of the output.
-
-v0.14.0 (unreleased)
---------------------
-
 * Base image for `Dockerfile` changed from `condaforge/mambaforge` to `condaforge/miniforge3`.
 * Removed `pytest-flake8` from development dependencies (incompatible with `pytest` v9.x).
 * Added `numpydoc-validation` to linters; Reformatted several function and class docstrings.

--- a/src/finch/processes/ensemble_utils.py
+++ b/src/finch/processes/ensemble_utils.py
@@ -369,7 +369,7 @@ def make_ensemble(  # noqa: D103
     )
     # make sure we have data starting in 1950
     ensemble = ensemble.sel(time=(ensemble.time.dt.year >= 1950))
-    
+
     if ensemble.lon.size == 1 and ensemble.lat.size == 1 and spatavg:
         ensemble.attrs["history"] = (
             f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] "
@@ -546,7 +546,9 @@ def ensemble_common_handler(  # noqa: C901,D103
     request_inputs_not_datasets = {
         k: v
         for k, v in request.inputs.items()
-        if k in xci_inputs and not k.startswith("perc") and not k.startswith("min_members")
+        if k in xci_inputs
+        and not k.startswith("perc")
+        and not k.startswith("min_members")
     }
 
     dataset_name = single_input_or_none(request.inputs, "dataset")
@@ -713,7 +715,7 @@ def ensemble_common_handler(  # noqa: C901,D103
             spatavg=spatavg,
             tmpavg=tmpavg,
             region=region,
-            min_members=min_members
+            min_members=min_members,
         )
         ensemble.attrs["source_datasets"] = "\n".join(
             [dsinp.url for dsinp in netcdf_inputs]

--- a/src/finch/processes/ensemble_utils.py
+++ b/src/finch/processes/ensemble_utils.py
@@ -362,13 +362,14 @@ def make_ensemble(  # noqa: D103
     spatavg: bool | None = False,
     tmpavg: bool | None = False,
     region: dict | None = None,
+    min_members: int | None = None,
 ) -> None:
     ensemble = ensembles.create_ensemble(
         files, realizations=[file.stem for file in files], decode_timedelta=False
     )
     # make sure we have data starting in 1950
     ensemble = ensemble.sel(time=(ensemble.time.dt.year >= 1950))
-
+    
     if ensemble.lon.size == 1 and ensemble.lat.size == 1 and spatavg:
         ensemble.attrs["history"] = (
             f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] "
@@ -428,7 +429,7 @@ def make_ensemble(  # noqa: D103
 
     if percentiles:
         ensemble_percentiles = ensembles.ensemble_percentiles(
-            ensemble, values=percentiles
+            ensemble, values=percentiles, min_members=min_members
         )
     else:
         ensemble_percentiles = ensemble
@@ -592,6 +593,7 @@ def ensemble_common_handler(  # noqa: C901,D103
         if percentiles_string != "None"
         else []
     )
+    min_members = single_input_or_none(request.inputs, "min_members")
 
     write_log(
         process,
@@ -711,6 +713,7 @@ def ensemble_common_handler(  # noqa: C901,D103
             spatavg=spatavg,
             tmpavg=tmpavg,
             region=region,
+            min_members=min_members
         )
         ensemble.attrs["source_datasets"] = "\n".join(
             [dsinp.url for dsinp in netcdf_inputs]

--- a/src/finch/processes/ensemble_utils.py
+++ b/src/finch/processes/ensemble_utils.py
@@ -545,7 +545,7 @@ def ensemble_common_handler(  # noqa: C901,D103
     request_inputs_not_datasets = {
         k: v
         for k, v in request.inputs.items()
-        if k in xci_inputs and not k.startswith("perc")
+        if k in xci_inputs and not k.startswith("perc") and not k.startswith("min_members")
     }
 
     dataset_name = single_input_or_none(request.inputs, "dataset")

--- a/src/finch/processes/wps_ensemble_indices_bbox.py
+++ b/src/finch/processes/wps_ensemble_indices_bbox.py
@@ -44,6 +44,7 @@ class XclimEnsembleBboxBase(FinchProcess):
             wpsio.ensemble_percentiles,
             wpsio.average,
             wpsio.temporal_average,
+            wpsio.min_members,
             *wpsio.get_ensemble_inputs(novar=True),
         ]
 

--- a/src/finch/processes/wps_ensemble_indices_point.py
+++ b/src/finch/processes/wps_ensemble_indices_point.py
@@ -42,6 +42,7 @@ class XclimEnsembleGridPointBase(FinchProcess):
             wpsio.ensemble_percentiles,
             wpsio.average,
             wpsio.temporal_average,
+            wpsio.min_members,
             *wpsio.get_ensemble_inputs(novar=True),
         ]
 

--- a/src/finch/processes/wps_ensemble_indices_polygon.py
+++ b/src/finch/processes/wps_ensemble_indices_polygon.py
@@ -40,6 +40,7 @@ class XclimEnsemblePolygonBase(FinchProcess):
             wpsio.ensemble_percentiles,
             wpsio.average,
             wpsio.temporal_average,
+            wpsio.min_members,
             *wpsio.get_ensemble_inputs(novar=True),
         ]
 

--- a/src/finch/processes/wpsio.py
+++ b/src/finch/processes/wpsio.py
@@ -132,7 +132,8 @@ temporal_average = LiteralInput(
 min_members = LiteralInput(
     "min_members",
     "Minimum number of members",
-    abstract="Minimum number of members required to compute the ensemble percentiles. If the number of members is lower than this value, the output will be missing.",
+    abstract="Minimum number of members required to compute the ensemble percentiles. \
+    If the number of members is lower than this value, the output will be missing.",
     data_type="integer",
     default=1,
     min_occurs=0,

--- a/src/finch/processes/wpsio.py
+++ b/src/finch/processes/wpsio.py
@@ -129,6 +129,14 @@ temporal_average = LiteralInput(
     min_occurs=0,
 )
 
+min_members = LiteralInput(
+    "min_members",
+    "Minimum number of members",
+    abstract="Minimum number of members required to compute the ensemble percentiles. If the number of members is lower than this value, the output will be missing.",
+    data_type="integer",
+    default=1,
+    min_occurs=0,
+)
 
 variable_any = LiteralInput(
     "variable",

--- a/tests/test_wps_ensemble.py
+++ b/tests/test_wps_ensemble.py
@@ -29,6 +29,40 @@ poly = {
     },
 }
 
+def test_ensemble_min_members(client):
+    # --- given ---
+    identifier = "ensemble_grid_point_tx_mean"
+    for min_members in [1, 2, 15, 29, 35]:
+        inputs = [
+            wps_literal_input("lat", "45.5"),
+            wps_literal_input("lon", "-73.0"),
+            wps_literal_input("scenario", "rcp45"),
+            wps_literal_input("dataset", "test_single_cell"),
+            wps_literal_input("freq", "MS"),
+            wps_literal_input("ensemble_percentiles", "20, 50, 80"),
+            wps_literal_input("output_format", "netcdf"),
+            wps_literal_input("output_name", "testens"),
+            wps_literal_input("min_members", str(min_members)),
+        ]
+
+        # --- when ---
+        outputs = execute_process(client, identifier, inputs)
+        outputs
+        assert len(outputs) == 1
+
+        # assert Path(outputs[0]).stem.startswith("testens_45_500_73_000_ssp245_ssp585")
+        ds = open_dataset(outputs[0])
+        for vv in ds.data_vars:
+            if min_members > 29: 
+                # 29 members in the test dataset, so if min_members > 29, all values should be NaN
+                assert ds[vv].isnull().all()
+            else:
+                # 29 members in the test dataset, so if min_members <= 29, we should have some non-NaN values
+                assert not ds[vv].isnull().all()
+
+    
+
+
 
 def test_ensemble_hxmax_days_above_grid_point(client):
     # --- given ---

--- a/tests/test_wps_ensemble.py
+++ b/tests/test_wps_ensemble.py
@@ -29,6 +29,7 @@ poly = {
     },
 }
 
+
 def test_ensemble_min_members(client):
     # --- given ---
     identifier = "ensemble_grid_point_tx_mean"
@@ -53,15 +54,12 @@ def test_ensemble_min_members(client):
         # assert Path(outputs[0]).stem.startswith("testens_45_500_73_000_ssp245_ssp585")
         ds = open_dataset(outputs[0])
         for vv in ds.data_vars:
-            if min_members > 29: 
+            if min_members > 29:
                 # 29 members in the test dataset, so if min_members > 29, all values should be NaN
                 assert ds[vv].isnull().all()
             else:
                 # 29 members in the test dataset, so if min_members <= 29, we should have some non-NaN values
                 assert not ds[vv].isnull().all()
-
-    
-
 
 
 def test_ensemble_hxmax_days_above_grid_point(client):


### PR DESCRIPTION
## Overview

Changes:

Exposes a new input parameter `min_members` for ensemble processes, allowing users to specify the minimum number of ensemble members required for calculations. This allows users to ensure that results are only produced when a sufficient number of members are available, enhancing the reliability of the output.