### PR TITLE
Drop lxml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -44,7 +44,6 @@ dependencies:
   - flake8-rst-docstrings >=0.4.0
   - flit >=3.11.0,<4.0
   - geojson
-  - lxml
   - nbsphinx >=0.9.8
   - nbval >=0.10.0
   - owslib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ dev = [
   "flake8-rst-docstrings >=0.4.0",
   "flit >=3.11.0,<4.0",
   "geojson",
-  "lxml",
   "matplotlib >=3.5.0",
   "nbconvert",
   "nbsphinx>=0.9.5",
@@ -323,7 +322,9 @@ ignore = [
   "COM", # commas
   "D205", # blank-line-after-summary
   "D400", # ends-in-period
-  "D401" # non-imperative-mood
+  "D401", # non-imperative-mood
+  "S314", # suspicious-xml-element-tree-usage
+  "S405" # suspicious-xml-etree-import
 ]
 preview = true
 select = [

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -50,12 +50,12 @@ def get_output(doc):  # noqa: D103
     return output
 
 
-def get_metalinks(doc: xml.etree.ElementTree):
+def get_metalinks(doc: xml.etree.ElementTree.Element):
     """Return a dictionary of metaurls found in metalink XML, keyed by their file name.
 
     Parameters
     ----------
-    doc : xml.etree.ElementTree
+    doc : xml.etree.ElementTree.Element
         Metalink XML etree.
     """
     output = {}

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -1,7 +1,7 @@
 # noqa: D100
+import xml.etree.ElementTree
 from pathlib import Path
 
-import lxml.etree
 from pywps import get_ElementMakerForVersion
 from pywps.app.basic import get_xpath_ns
 from pywps.tests import WpsClient, WpsTestResponse
@@ -50,16 +50,16 @@ def get_output(doc):  # noqa: D103
     return output
 
 
-def get_metalinks(doc: lxml.etree.Element):
+def get_metalinks(doc: xml.etree.ElementTree):
     """Return a dictionary of metaurls found in metalink XML, keyed by their file name.
 
     Parameters
     ----------
-    doc : lxml.etree.Element
+    doc : xml.etree.ElementTree
         Metalink XML etree.
     """
     output = {}
-    for child in doc.iterchildren():
+    for child in doc:
         if child.tag == "{urn:ietf:params:xml:ns:metalink}file":
             url = child.find("{urn:ietf:params:xml:ns:metalink}metaurl")
             output[child.attrib["name"]] = url.text

--- a/tests/test_wps_xclim_indices.py
+++ b/tests/test_wps_xclim_indices.py
@@ -1,4 +1,5 @@
 import json
+import xml.etree.ElementTree
 from pathlib import Path
 from unittest import mock
 from zipfile import ZipFile
@@ -7,7 +8,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from lxml import etree
 from numpy.testing import assert_equal
 from pywps.app.exceptions import ProcessError
 from xclim.testing import open_dataset
@@ -141,7 +141,7 @@ def test_wps_daily_temperature_range_multiple(client, netcdf_datasets):
     assert mock_progress.call_args_list[4][1]["end_percentage"] == 100
 
     # FIXME: This is generally unsafe as an approach as the data is untrusted.
-    et = etree.fromstring(outputs[1].data[0].encode())  # noqa: S320
+    et = xml.etree.ElementTree.fromstring(outputs[1].data[0].encode())  # noqa: S320
     urls = [e[2].text for e in et if e.tag.endswith("file")]
 
     assert len(urls) == 5, "Containing 10 files"

--- a/tests/test_wps_xsubset_point.py
+++ b/tests/test_wps_xsubset_point.py
@@ -1,3 +1,4 @@
+import xml.etree.ElementTree
 import zipfile
 from pathlib import Path
 
@@ -60,8 +61,6 @@ def test_wps_multiple_xsubsetpoint(netcdf_datasets):
 
 @pytest.mark.online
 def test_thredds():
-    import lxml.etree
-
     client = client_for(
         Service(processes=[SubsetGridPointProcess()], cfgfiles=CFG_FILE)
     )
@@ -82,7 +81,9 @@ def test_thredds():
     assert_response_success(resp)
     out = get_output(resp.xml)
     # FIXME: This is generally unsafe as an approach as the data is untrusted.
-    links = get_metalinks(lxml.etree.fromstring(out["ref"].encode()))  # noqa: S320
+    links = get_metalinks(
+        xml.etree.ElementTree.fromstring(out["ref"].encode())
+    )  # noqa: S320
     assert len(links) == 2
 
 


### PR DESCRIPTION
## Overview

This PR fixes #550

Changes:

* Remove `lxml` as a dependency, replace with built-in  `xml.etree.ElementTree`. We were using two functions from `lxml`, without any of the added features.
* `xml.etree.ElementTree` is vulnerable to some well known attacks and `ruff` was warning about it. However, we only use it in the tests and with xml sources we generated ourselves. So I disabled the warnings.

## Additional Information
~However, `lxml` is dependency of `pywps`.  This PR makes it so WE don't _explicitly_ install it, but it is still present in the environment, the responsibility is shifted upstream.~