### PR TITLE
Hotfix version, adjust concurrency, use prek

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,7 @@ on:
 concurrency:
   # For a given workflow, if we push to the same branch, cancel all previous builds on that branch except on master.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,10 @@ jobs:
       - name: Run pylint
         run: |
           python -m pylint --rcfile=.pylintrc.toml --disable=import-error --exit-zero src/finch
-      - name: Run pre-commit
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - name: Run prek
+        uses: j178/prek-action@5337cb91e0fa35a7ff31b9ca345126d8bbbcdf16 # v2.0.6
+        with:
+          extra-args: --skip no-commit-to-branch
 
   conda:
     name: Build ⚙️ and test 🧪

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,7 @@ regex = true
 [[tool.bumpversion.files]]
 filename = "src/finch/__version__.py"
 search = "__version__ = \"{current_version}\""
-replace = "__version__ = \"{new_version}\n"
+replace = "__version__ = \"{new_version}\""
 
 [[tool.bumpversion.files]]
 filename = ".cruft.json"

--- a/src/finch/__version__.py
+++ b/src/finch/__version__.py
@@ -6,5 +6,4 @@
 
 __author__ = """David Huard"""
 __email__ = "huard.david@ouranos.ca"
-__version__ = "0.13.3-dev.6
-
+__version__ = "0.13.3-dev.6"


### PR DESCRIPTION
## Overview

This PR fixes the version string which was badly formatted by `bump-my-version` and adjusts some CI logic.

Changes:

* Corrected the version string replacement field for `__version__.py`
* Set `docker-publish.yml` to cancel in-progress builds when commits are rapidly pushed to `main`
* Migrated CI checks with `pre-commit` to `prek` and configured it to never fail the `no-commit-to-branch` check (for `main`).

## Related Issue / Discussion

It might be a good idea to try updating `xclim` and performing a release next week. I feel like that would be reasonable.
