### PR TITLE
Use accurate docker image name

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,7 +38,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          images: pavics/raven
+          images: birdhouse/finch
           labels: |
             org.opencontainers.image.authors=Birdhouse and Ouranosinc
             org.opencontainers.image.description=Finch WPS


### PR DESCRIPTION
## Overview

Not sure how I missed this, but last I checked, this was `finch`.

Changes:

* Corrected image name from `pavics/raven` to `birdhouse/finch`

## Additional Information

`pavics/raven:latest` has been purged from the Dockerhub.